### PR TITLE
fix: python: retriving pkg.type.

### DIFF
--- a/libcomps/src/python/pycomps_groups.c
+++ b/libcomps/src/python/pycomps_groups.c
@@ -958,19 +958,10 @@ int PyCOMPSPack_set_name(PyCOMPS_Package *self, PyObject *value, void *closure) 
 
 PyObject* PyCOMPSPack_get_type(PyCOMPS_Package *self, void *closure) {
    (void) closure;
-    switch (pycomps_pkg_get((PyObject*)self)->type) {
-        case COMPS_PACKAGE_DEFAULT:
-            return Py_BuildValue("%d",0);
-        case COMPS_PACKAGE_OPTIONAL:
-            return Py_BuildValue("%d",1);
-        case COMPS_PACKAGE_MANDATORY:
-            return Py_BuildValue("%d",2);
-        case COMPS_PACKAGE_UNKNOWN:
-            return Py_BuildValue("%d",3);
-        case COMPS_PACKAGE_CONDITIONAL:
-            return Py_BuildValue("%d",4);
-    }
-    Py_RETURN_NONE;
+   int type = pycomps_pkg_get((PyObject*)self)->type;
+   if (type >= 0 && type <= COMPS_PACKAGE_UNKNOWN)
+       return Py_BuildValue("i", type);
+   Py_RETURN_NONE;
 }
 
 int PyCOMPSPack_set_type(PyCOMPS_Package *self, PyObject *value, void *closure){

--- a/libcomps/src/python/tests/__test.py
+++ b/libcomps/src/python/tests/__test.py
@@ -3,6 +3,12 @@ import unittest
 import tempfile
 import os
 
+class PackageTest(unittest.TestCase):
+    def test_attrs(self):
+        pkg = libcomps.Package("kernel-3.2", libcomps.PACKAGE_TYPE_MANDATORY)
+        self.assertEqual(pkg.name, "kernel-3.2")
+        self.assertEqual(pkg.type, libcomps.PACKAGE_TYPE_MANDATORY)
+
 class CategoryListTest(unittest.TestCase):
     def setUp(self):
         self.catlist = libcomps.CategoryList()
@@ -742,7 +748,8 @@ class COMPSTest(unittest.TestCase):
         self.assertTrue(eids3_set == eids_set)
 
 if __name__ == "__main__":
-    #unittest.main()
+    suite = unittest.TestLoader().loadTestsFromTestCase(PackageTest)
+    unittest.TextTestRunner(verbosity=2).run(suite)
     suite = unittest.TestLoader().loadTestsFromTestCase(CategoryTest)
     unittest.TextTestRunner(verbosity=2).run(suite)
     suite = unittest.TestLoader().loadTestsFromTestCase(GroupTest)
@@ -758,6 +765,3 @@ if __name__ == "__main__":
     unittest.TextTestRunner(verbosity=2).run(suite)
     suite = unittest.TestLoader().loadTestsFromTestCase(EnvListTest)
     unittest.TextTestRunner(verbosity=2).run(suite)
-
-
-


### PR DESCRIPTION
The exact error was "SystemError: bad format char passed to Py_BuildValue".
