### PR TITLE
Python: respect CMAKE_INSTALL_PREFIX

### DIFF
--- a/libcomps/src/python/src/python2/CMakeLists.txt
+++ b/libcomps/src/python/src/python2/CMakeLists.txt
@@ -1,7 +1,12 @@
 find_package (PythonLibs 2.6)
 find_package (PythonInterp 2.6 REQUIRED)
 
-execute_process (COMMAND ${PYTHON_EXECUTABLE} -c "from sys import stdout; from distutils import sysconfig; stdout.write(sysconfig.get_python_lib(True))" OUTPUT_VARIABLE PYTHON_INSTALL_DIR)
+EXECUTE_PROCESS(COMMAND ${PYTHON_EXECUTABLE} -c "
+from sys import stdout
+from distutils import sysconfig
+path=sysconfig.get_python_lib(True, prefix='${CMAKE_INSTALL_PREFIX}')
+stdout.write(path)"
+OUTPUT_VARIABLE PYTHON_INSTALL_DIR)
 
 include_directories(${PYTHON_INCLUDE_PATH})
 include_directories(${LIBCOMPS_INCLUDE_PATH})

--- a/libcomps/src/python/src/python3/CMakeLists.txt
+++ b/libcomps/src/python/src/python3/CMakeLists.txt
@@ -2,7 +2,12 @@ find_package (PythonLibs 3.0)
 find_package (PythonInterp 3.0)
 #add_custom_target(py3-copy)
 
-execute_process (COMMAND ${PYTHON_EXECUTABLE} -c "from sys import stdout; from distutils import sysconfig; stdout.write(sysconfig.get_python_lib(True))" OUTPUT_VARIABLE PYTHON_INSTALL_DIR)
+EXECUTE_PROCESS(COMMAND ${PYTHON_EXECUTABLE} -c "
+from sys import stdout
+from distutils import sysconfig
+path=sysconfig.get_python_lib(True, prefix='${CMAKE_INSTALL_PREFIX}')
+stdout.write(path)"
+OUTPUT_VARIABLE PYTHON_INSTALL_DIR)
 
 include_directories(${PYTHON_INCLUDE_PATH})
 include_directories(${LIBCOMPS_INCLUDE_PATH})


### PR DESCRIPTION
While packaging I noticed it tried to put the modules in the wrong
folder.