### PR TITLE
Up cmake version requirement (post-factual), remove LIB_SUFFIX and LIB_INST_DIR.

### DIFF
--- a/build_prep.cmake
+++ b/build_prep.cmake
@@ -155,10 +155,6 @@ foreach(tag ${tags})
     set(last_tag ${tag_out})
 endforeach(tag ${tags})
 
-IF (CMAKE_SIZEOF_VOID_P MATCHES "8")
-    SET (LIB_SUFFIX "64")
-ENDIF (CMAKE_SIZEOF_VOID_P MATCHES "8")
-
 set(VERSION ${libcomps_VERSION_MAJOR}.${libcomps_VERSION_MINOR}.${libcomps_VERSION_PATCH})
 
 exec_program("git" ARGS rev-parse --short ${TOP_COMMIT} OUTPUT_VARIABLE GITREV)

--- a/libcomps/CMakeLists.txt
+++ b/libcomps/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(libcomps)
 
-cmake_minimum_required (VERSION 2.6)
+cmake_minimum_required (VERSION 3.0.2)
 include (${CMAKE_ROOT}/Modules/CheckFunctionExists.cmake)
 include (${CMAKE_SOURCE_DIR}/version.cmake)
 #set (CMAKE_CXX_COMPILER g++)

--- a/libcomps/src/CMakeLists.txt
+++ b/libcomps/src/CMakeLists.txt
@@ -51,9 +51,6 @@ set_target_properties(libcomps PROPERTIES SOVERSION ${VERSION})
 
 add_dependencies(libcomps src-copy)
 
-IF (CMAKE_SIZEOF_VOID_P MATCHES "8")
-    SET (LIB_SUFFIX "64")
-ENDIF (CMAKE_SIZEOF_VOID_P MATCHES "8")
 set (LIB_INST_DIR ${CMAKE_INSTALL_LIBDIR})
 
 

--- a/libcomps/src/CMakeLists.txt
+++ b/libcomps/src/CMakeLists.txt
@@ -51,15 +51,13 @@ set_target_properties(libcomps PROPERTIES SOVERSION ${VERSION})
 
 add_dependencies(libcomps src-copy)
 
-set (LIB_INST_DIR ${CMAKE_INSTALL_LIBDIR})
-
 
 configure_file("${PROJECT_SOURCE_DIR}/../libcomps.pc.in" "${CMAKE_CURRENT_BINARY_DIR}/libcomps.pc" @ONLY)
 
 install (FILES ${libcomps_HEADERS} DESTINATION include/libcomps)
-install (TARGETS libcomps LIBRARY DESTINATION ${LIB_INST_DIR})
+install (TARGETS libcomps LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install (FILES "${CMAKE_CURRENT_BINARY_DIR}/libcomps.pc"
-         DESTINATION "${LIB_INST_DIR}/pkgconfig/")
+         DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig/")
 
 add_subdirectory(python)
 


### PR DESCRIPTION
**Requires PR #52 to be merged first!**
---
We're already using cmake features introduced with 3.0, so we might as well post-factual update the required cmake version.

With `libcomps.pc.in` fixed, we can also drop `LIB_SUFFIX` completely.

Since `LIB_INST_DIR` has degraded into an indirection for `CMAKE_INSTALL_LIBDIR`, drop that as well and use `${CMAKE_INSTALL_LIBDIR}` directly.