### PR TITLE
Empty dict created by *_by_lang in python api causes segfault (RhBug:1757959)

### DIFF
--- a/libcomps/src/python/src/pycomps_dict.c
+++ b/libcomps/src/python/src/pycomps_dict.c
@@ -78,7 +78,7 @@ PyObject* PyCOMPSDict_str(PyObject *self) {
     pairlist = comps_objdict_pairs(((PyCOMPS_Dict*)self)->dict);
     char *tmpstr;
 
-    for (it = pairlist->first; it != pairlist->last; it = it->next) {
+    for (it = pairlist->first; it != NULL; it = it->next) {
         tmp = ret;
         tmpkey = __pycomps_lang_decode(((COMPS_ObjRTreePair*)it->data)->key);
         if (!tmpkey) {
@@ -99,24 +99,6 @@ PyObject* PyCOMPSDict_str(PyObject *self) {
         Py_XDECREF(tmpkey);
         Py_XDECREF(tmpval);
     }
-    tmp = ret;
-    tmpkey = __pycomps_lang_decode(((COMPS_RTreePair*)it->data)->key);
-    if (!tmpkey) {
-        goto out;
-    }
-    tmpstr = comps_object_tostr(((COMPS_ObjRTreePair*)it->data)->data);
-    tmpval = __pycomps_lang_decode(tmpstr);
-    free(tmpstr);
-    if (!tmpval) {
-        //PyErr_SetString(PyExc_TypeError, "val convert error");
-        goto out;
-    }
-    tmp2 = PyUnicode_FromFormat("%U = '%U'", tmpkey, tmpval);
-    ret = PyUnicode_Concat(ret, tmp2);
-    Py_XDECREF(tmp);
-    Py_XDECREF(tmp2);
-    Py_XDECREF(tmpkey);
-    Py_XDECREF(tmpval);
     
     tmp = ret;
     tmp2 = PyUnicode_FromString("}");

--- a/libcomps/src/python/tests/__test.py
+++ b/libcomps/src/python/tests/__test.py
@@ -225,7 +225,7 @@ class BaseObjTestClass(object):
     def test_hash(self):
         s = set()
         for x in range(6):
-            s.add(self.obj_constructor(**self.obj_data[x/2]))
+            s.add(self.obj_constructor(**self.obj_data[int(x/2)]))
         self.assertTrue(len(s) == 3)
         self.assertTrue(hash(self.obj_constructor(**self.obj_data[0])) ==\
                         hash(self.obj_constructor(**self.obj_data[0])))

--- a/libcomps/src/python/tests/comps/comps_empty_by_lang_tags.xml
+++ b/libcomps/src/python/tests/comps/comps_empty_by_lang_tags.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE comps PUBLIC "-//Red Hat, Inc.//DTD Comps info//EN" "comps.dtd">
+<comps>
+  <group>
+   <id>birds</id>
+   <description></description>
+  </group>
+  <category>
+   <id>all</id>
+   <name>all</name>
+  </category>
+</comps>

--- a/libcomps/src/python/tests/test_libcomps.py
+++ b/libcomps/src/python/tests/test_libcomps.py
@@ -153,6 +153,16 @@ class TestLibcomps(unittest.TestCase):
         #print self.comps.xml_str()
         self.comps.fromxml_str(self.comps.xml_str())
 
+    def test_empty_by_lang_tags(self):
+        self.comps = libcomps.Comps()
+        self.comps.fromxml_f("comps/comps_empty_by_lang_tags.xml")
+        for group in self.comps.groups:
+            self.assertEqual("{}", str(group.name_by_lang))
+            self.assertEqual("{}", str(group.desc_by_lang))
+
+        for category in self.comps.categories:
+            self.assertEqual("{}", str(category.name_by_lang))
+            self.assertEqual("{}", str(category.desc_by_lang))
 
 if __name__ == "__main__":
     unittest.main(testRunner = utest.MyRunner)

--- a/libcomps/src/python/tests/test_libcomps.py
+++ b/libcomps/src/python/tests/test_libcomps.py
@@ -19,7 +19,6 @@ except ImportError:
 class TestLibcomps(unittest.TestCase):
 
     def setUp(self):
-        print (dir(libcomps))
         self.comps = libcomps.Comps()
         self.comps.fromxml_f("comps/comps-f21.xml")
         self.tmp_dir = tempfile.mkdtemp()

--- a/libcomps/src/python/tests/test_merge_comps.py
+++ b/libcomps/src/python/tests/test_merge_comps.py
@@ -7,10 +7,10 @@ import utest
 
 try:
     import _libpycomps as libcomps
-    print "local tests"
+    print("local tests")
 except ImportError:
     import libcomps
-    print "global tests"
+    print("global tests")
 
 
 class TestMergeComps(unittest.TestCase):


### PR DESCRIPTION
The problem was de-referencing it->data when it was NULL.

I have also added a commit with a test, but I don't think these tests run when building rpms.

https://bugzilla.redhat.com/show_bug.cgi?id=1757959