### PR TITLE
Add missing python metadata to python2/3-libcomps

### DIFF
--- a/libcomps.spec
+++ b/libcomps.spec
@@ -182,11 +182,13 @@ popd
 %if %{with python2}
 %files -n python2-%{name}
 %{python2_sitearch}/%{name}/
+%{python2_sitearch}/%{name}-%{version}-py%{python2_version}.egg-info
 %endif
 
 %if %{with python3}
 %files -n python3-%{name}
 %{python3_sitearch}/%{name}/
+%{python3_sitearch}/%{name}-%{version}-py%{python3_version}.egg-info
 %endif
 
 %changelog

--- a/libcomps/src/python/src/python2/CMakeLists.txt
+++ b/libcomps/src/python/src/python2/CMakeLists.txt
@@ -53,3 +53,6 @@ INSTALL(FILES ${pycomps_SRCDIR}/__init__.py DESTINATION ${PYTHON_INSTALL_DIR}/li
 #INSTALL(FILES ${pycomps_SRCDIR}/tests/main_comps2.xml DESTINATION
 #              ${PYTHON_INSTALL_DIR}/libcomps/)
 INSTALL (TARGETS pycomps LIBRARY DESTINATION ${PYTHON_INSTALL_DIR}/libcomps)
+
+# Version has to be passed as last argument.
+INSTALL(CODE "EXECUTE_PROCESS(COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/../setup_for_python_metadata.py install_egg_info --install-dir \$ENV{DESTDIR}/${PYTHON_INSTALL_DIR} ${VERSION})")

--- a/libcomps/src/python/src/python3/CMakeLists.txt
+++ b/libcomps/src/python/src/python3/CMakeLists.txt
@@ -46,3 +46,6 @@ INSTALL(FILES ${pycomps_SRCDIR}/__init__.py DESTINATION ${PYTHON_INSTALL_DIR}/li
 #INSTALL(FILES ${pycomps_SRCDIR}/tests/main_comps2.xml DESTINATION
 #              ${PYTHON_INSTALL_DIR}/libcomps/)
 INSTALL (TARGETS pycomps LIBRARY DESTINATION ${PYTHON_INSTALL_DIR}/libcomps)
+
+# Version has to be passed as last argument.
+INSTALL(CODE "EXECUTE_PROCESS(COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/../setup_for_python_metadata.py install_egg_info --install-dir \$ENV{DESTDIR}/${PYTHON_INSTALL_DIR} ${VERSION})")

--- a/setup_for_python_metadata.py
+++ b/setup_for_python_metadata.py
@@ -1,0 +1,33 @@
+from distutils.core import setup
+import sys
+
+# This is a simple and fragile way of passing the current version
+# from cmake to setup as I assume no one else will use this.
+#
+# This script has to have the version always specified as last argument.
+version = sys.argv.pop()
+
+setup(
+    name='libcomps',
+    description='Comps XML file manipulation library',
+    version=version,
+    license='GPLv2+',
+    author='RPM Software Management',
+    author_email='rpm-ecosystem@lists.rpm.org',
+    url='https://github.com/rpm-software-management',
+    classifiers=[
+        'License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)',
+        'Operating System :: POSIX :: Linux',
+        'Programming Language :: C',
+        'Topic :: System :: Software Distribution',
+        'Topic :: System :: Systems Administration',
+        "Programming Language :: Python :: 2",
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+    ],
+)


### PR DESCRIPTION
Adapted from:
https://github.com/rpm-software-management/createrepo_c/pull/167

setup_for_python_metadata.py uses distutils, and is
used to generate egg-info metadata during building of packages.