### PR TITLE
Use libs rather than requires

### DIFF
--- a/libcomps.pc.in
+++ b/libcomps.pc.in
@@ -5,6 +5,6 @@ libdir=@CMAKE_INSTALL_FULL_LIBDIR@
 Name: libcomps
 Description: alternative for yum.libcomps written in C
 Version: @VERSION@
-Requires: -L${libdir} -lcomps
-Reuires.private: -lxml2 -lexpat
+Libs: -L${libdir} -lcomps
+Libs.private: -lxml2 -lexpat
 CFlags: -I${includedir}


### PR DESCRIPTION
This fixes wrong provides generation by rpm
DEBUG util.py:585:  BUILDSTDERR:  Problem: conflicting requests
DEBUG util.py:585:  BUILDSTDERR:   - nothing provides pkgconfig(-L/usr/lib64) needed by lib64comps-devel-0.1.12-1.x86_64
DEBUG util.py:585:  BUILDSTDERR:   - nothing provides pkgconfig(-lcomps) needed by lib64comps-devel-0.1.12-1.x86_64
DEBUG util.py:587:  (try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)