### PR TITLE
Do not skip type=mandatory in xml output and test it (RhBug:1771224)

### DIFF
--- a/libcomps/src/comps_docpackage.c
+++ b/libcomps/src/comps_docpackage.c
@@ -164,8 +164,9 @@ signed char comps_docpackage_xml(COMPS_DocGroupPackage *pkg,
         str = "conditional";
     else
         str = "default";
-    if (pkg->type != COMPS_PACKAGE_MANDATORY)
-        ret = xmlTextWriterWriteAttribute(writer, BAD_CAST "type", BAD_CAST str);
+
+    ret = xmlTextWriterWriteAttribute(writer, BAD_CAST "type", BAD_CAST str);
+
     if (pkg->requires) {
         str = comps_object_tostr((COMPS_Object*)pkg->requires);
         ret = xmlTextWriterWriteAttribute(writer, (xmlChar*) "requires",

--- a/libcomps/src/python/tests/__test.py
+++ b/libcomps/src/python/tests/__test.py
@@ -620,6 +620,14 @@ class PackageTest(unittest.TestCase):
         self.assertTrue(hash(pkg2) != hash(pkg3))
         self.assertTrue(len(set([pkg1,pkg2,pkg3])) == 2)
 
+    def test_mandatory_in_xml_out(self):
+        self.comps = libcomps.Comps()
+        self.comps.groups.append(libcomps.Group("g1", "group1", "group desc", 0, 0, 0, "en"))
+        self.comps.groups[0].packages.append(libcomps.Package("kernel", libcomps.PACKAGE_TYPE_MANDATORY))
+
+        out = self.comps.xml_str()
+        self.assertTrue("<packagereq type=\"mandatory\" requires=\"\">kernel</packagereq>" in out)
+
 #@unittest.skip("skip")
 class DictTest(unittest.TestCase):
     def test_dict(self):
@@ -998,7 +1006,7 @@ class COMPSTest(unittest.TestCase):
         self.assertEqual(len(comps2.groups), 0)
         self.assertEqual(len(comps2.categories), 0)
         self.assertEqual(len(comps2.environments), 0)
-        
+
         s = comps.toxml_str(xml_options={"empty_groups": True,
                                      "empty_categories": True,
                                      "empty_environments": True})


### PR DESCRIPTION
The mandatory type is used when no other configuration and no other
type is specified but since this behavior can be overridden with passed
configuration it doesn't make sense to always skip outputting the type
mandatory.
The user can specify for example optional type as default and then
the knowledge that some specific <packagereq> were mandatory would be
lost.

https://bugzilla.redhat.com/show_bug.cgi?id=1771224