### PR TITLE
Fix build on musl systems

### DIFF
--- a/libcomps/src/comps_log_codes.h
+++ b/libcomps/src/comps_log_codes.h
@@ -52,25 +52,25 @@ inline void expand0(char *str, const char *fmt, char **args, char out) {
     (void)args;
     __expand(str, fmt, out);
 }
-inline void expand1(char *str, const char *fmt, char **args, char out) {
+static inline void expand1(char *str, const char *fmt, char **args, char out) {
     __expand(str, fmt, out, args[0]);
 }
-inline void expand2(char *str, const char *fmt, char **args, char out) {
+static inline void expand2(char *str, const char *fmt, char **args, char out) {
     __expand(str, fmt, out, args[0],
                           args[1]);
 }
-inline void expand3(char *str, const char *fmt, char **args, char out) {
+static inline void expand3(char *str, const char *fmt, char **args, char out) {
     __expand(str, fmt, out, args[0],
                            args[1],
                            args[2]);
 }
-inline void expand4(char *str, const char *fmt, char **args, char out) {
+static inline void expand4(char *str, const char *fmt, char **args, char out) {
     __expand(str, fmt, out, args[0],
                            args[1],
                            args[2],
                            args[3]);
 }
-inline void expand5(char *str, const char *fmt, char **args, char out) {
+static inline void expand5(char *str, const char *fmt, char **args, char out) {
     __expand(str, fmt, out, args[0],
                            args[1],
                            args[2],
@@ -80,10 +80,10 @@ inline void expand5(char *str, const char *fmt, char **args, char out) {
 
 void expand(char *str, const char *fmt, char **args, int len, int out);
 
-inline void expand_out(const char *fmt, char **args, int len) {
+static inline void expand_out(const char *fmt, char **args, int len) {
     expand(NULL, fmt, args, len, 1);
 }
-inline void expand_s(char *str, const char *fmt, char **args, int len) {
+static inline void expand_s(char *str, const char *fmt, char **args, int len) {
     expand(str, fmt, args, len, 0);
 }
 

--- a/libcomps/src/python/src/pycomps_sequence.c
+++ b/libcomps/src/python/src/pycomps_sequence.c
@@ -29,7 +29,7 @@ Py_ssize_t PyCOMPSSeq_len(PyObject *self) {
     return ((PyCOMPS_Sequence*)self)->list->len;
 }
 
-inline PyObject* list_getitem(PyObject *self, Py_ssize_t index) {
+static inline PyObject* list_getitem(PyObject *self, Py_ssize_t index) {
     COMPS_Object *obj;
     PyObject *ret;
     int i;
@@ -47,7 +47,7 @@ inline PyObject* list_getitem(PyObject *self, Py_ssize_t index) {
     return ret;
 }
 
-inline PyObject* list_getitem_byid(PyObject *self, PyObject *id) {
+static inline PyObject* list_getitem_byid(PyObject *self, PyObject *id) {
     #define _seq_ ((PyCOMPS_Sequence*)self)
     char *strid=NULL;
     COMPS_ObjListIt *it;
@@ -90,7 +90,7 @@ inline PyObject* list_getitem_byid(PyObject *self, PyObject *id) {
     #undef _seq_
 }
 
-inline COMPS_Object *list_setitem_convert(PyObject *self, PyObject *item) {
+static inline COMPS_Object *list_setitem_convert(PyObject *self, PyObject *item) {
     #define _seq_ ((PyCOMPS_Sequence*)self)
     COMPS_Object *ret = NULL;
     if (!item)
@@ -107,7 +107,7 @@ inline COMPS_Object *list_setitem_convert(PyObject *self, PyObject *item) {
     #undef _seq_
 }
 
-inline int list_setitem(PyObject *self, Py_ssize_t index, PyObject *item) {
+static inline int list_setitem(PyObject *self, Py_ssize_t index, PyObject *item) {
     #define _seq_ ((PyCOMPS_Sequence*)self)
     COMPS_Object *converted_item = list_setitem_convert(self, item);
     if (!converted_item && item) {
@@ -161,7 +161,7 @@ int list_unique_id_check(PyObject *self, COMPS_Object *converted) {
     return 0;
 }
 
-inline int list_setitem_id_unique(PyObject *self,
+static inline int list_setitem_id_unique(PyObject *self,
                                   Py_ssize_t index,
                                   PyObject *item) {
     #define _seq_ ((PyCOMPS_Sequence*)self)


### PR DESCRIPTION
Hi, I'm creating a Linux distribution which uses musl libc as default C library implementation. When I try to compile `libcomps` ninja gives me this:
```
[53/59] Linking C executable tests/test_brtree
FAILED: tests/test_brtree 
: && /usr/lib/ccache/bin/gcc --pedantic -std=c99 -Wall -Wextra -g -Wno-missing-field-initializers -O2 -fno-strict-aliasing -g -Os -DNDEBUG -rdynamic tests/CMakeFiles/test_brtree.dir/check_brtree.c.o tests/CMakeFiles/test_brtree.dir/check_utils.c.o -o tests/test_brtree  -Wl,-rpath,/usr/ports/packages/libcomps/work/src/libcomps-libcomps-0.1.15/build/src  src/libcomps.so.0  -lcheck  -lexpat  -lxml2  -lz  -lm && :
/usr/bin/ld: src/libcomps.so.0: undefined reference to `expand2'
/usr/bin/ld: src/libcomps.so.0: undefined reference to `expand4'
/usr/bin/ld: src/libcomps.so.0: undefined reference to `expand_s'
/usr/bin/ld: src/libcomps.so.0: undefined reference to `expand3'
/usr/bin/ld: src/libcomps.so.0: undefined reference to `expand5'
/usr/bin/ld: src/libcomps.so.0: undefined reference to `expand_out'
collect2: error: ld returned 1 exit status
[54/59] Linking C executable tests/test_validate
FAILED: tests/test_validate 
: && /usr/lib/ccache/bin/gcc --pedantic -std=c99 -Wall -Wextra -g -Wno-missing-field-initializers -O2 -fno-strict-aliasing -g -Os -DNDEBUG -rdynamic tests/CMakeFiles/test_validate.dir/check_validate.c.o -o tests/test_validate  -Wl,-rpath,/usr/ports/packages/libcomps/work/src/libcomps-libcomps-0.1.15/build/src  src/libcomps.so.0  -lcheck  -lexpat  -lxml2  -lz  -lm && :
/usr/bin/ld: src/libcomps.so.0: undefined reference to `expand2'
/usr/bin/ld: src/libcomps.so.0: undefined reference to `expand4'
/usr/bin/ld: src/libcomps.so.0: undefined reference to `expand_s'
/usr/bin/ld: src/libcomps.so.0: undefined reference to `expand3'
/usr/bin/ld: src/libcomps.so.0: undefined reference to `expand5'
/usr/bin/ld: src/libcomps.so.0: undefined reference to `expand_out'
collect2: error: ld returned 1 exit status
[55/59] Linking C executable tests/test_rtree
FAILED: tests/test_rtree 
: && /usr/lib/ccache/bin/gcc --pedantic -std=c99 -Wall -Wextra -g -Wno-missing-field-initializers -O2 -fno-strict-aliasing -g -Os -DNDEBUG -rdynamic tests/CMakeFiles/test_rtree.dir/check_rtree.c.o tests/CMakeFiles/test_rtree.dir/check_utils.c.o -o tests/test_rtree  -Wl,-rpath,/usr/ports/packages/libcomps/work/src/libcomps-libcomps-0.1.15/build/src  src/libcomps.so.0  -lcheck  -lexpat  -lxml2  -lz  -lm && :
/usr/bin/ld: src/libcomps.so.0: undefined reference to `expand2'
/usr/bin/ld: src/libcomps.so.0: undefined reference to `expand4'
/usr/bin/ld: src/libcomps.so.0: undefined reference to `expand_s'
/usr/bin/ld: src/libcomps.so.0: undefined reference to `expand3'
/usr/bin/ld: src/libcomps.so.0: undefined reference to `expand5'
/usr/bin/ld: src/libcomps.so.0: undefined reference to `expand_out'
collect2: error: ld returned 1 exit status
[56/59] Linking C executable tests/test_objrtree
FAILED: tests/test_objrtree 
: && /usr/lib/ccache/bin/gcc --pedantic -std=c99 -Wall -Wextra -g -Wno-missing-field-initializers -O2 -fno-strict-aliasing -g -Os -DNDEBUG -rdynamic tests/CMakeFiles/test_objrtree.dir/check_objrtree.c.o tests/CMakeFiles/test_objrtree.dir/check_utils.c.o -o tests/test_objrtree  -Wl,-rpath,/usr/ports/packages/libcomps/work/src/libcomps-libcomps-0.1.15/build/src  src/libcomps.so.0  -lcheck  -lexpat  -lxml2  -lz  -lm && :
/usr/bin/ld: src/libcomps.so.0: undefined reference to `expand2'
/usr/bin/ld: src/libcomps.so.0: undefined reference to `expand4'
/usr/bin/ld: src/libcomps.so.0: undefined reference to `expand_s'
/usr/bin/ld: src/libcomps.so.0: undefined reference to `expand3'
/usr/bin/ld: src/libcomps.so.0: undefined reference to `expand5'
/usr/bin/ld: src/libcomps.so.0: undefined reference to `expand_out'
collect2: error: ld returned 1 exit status
[57/59] Linking C executable tests/test_comps
FAILED: tests/test_comps 
: && /usr/lib/ccache/bin/gcc --pedantic -std=c99 -Wall -Wextra -g -Wno-missing-field-initializers -O2 -fno-strict-aliasing -g -Os -DNDEBUG -rdynamic tests/CMakeFiles/test_comps.dir/check_comps.c.o -o tests/test_comps  -Wl,-rpath,/usr/ports/packages/libcomps/work/src/libcomps-libcomps-0.1.15/build/src  -lexpat  -lcheck  src/libcomps.so.0  -lexpat  -lxml2  -lz  -lm && :
/usr/bin/ld: src/libcomps.so.0: undefined reference to `expand2'
/usr/bin/ld: src/libcomps.so.0: undefined reference to `expand4'
/usr/bin/ld: src/libcomps.so.0: undefined reference to `expand_s'
/usr/bin/ld: src/libcomps.so.0: undefined reference to `expand3'
/usr/bin/ld: src/libcomps.so.0: undefined reference to `expand5'
/usr/bin/ld: src/libcomps.so.0: undefined reference to `expand_out'
collect2: error: ld returned 1 exit status
[58/59] Linking C executable tests/test_parse
FAILED: tests/test_parse 
: && /usr/lib/ccache/bin/gcc --pedantic -std=c99 -Wall -Wextra -g -Wno-missing-field-initializers -O2 -fno-strict-aliasing -g -Os -DNDEBUG -rdynamic tests/CMakeFiles/test_parse.dir/check_parse.c.o tests/CMakeFiles/test_parse.dir/check_utils.c.o -o tests/test_parse  -Wl,-rpath,/usr/ports/packages/libcomps/work/src/libcomps-libcomps-0.1.15/build/src  src/libcomps.so.0  -lexpat  -lcheck  -lexpat  -lxml2  -lz  -lm && :
/usr/bin/ld: src/libcomps.so.0: undefined reference to `expand2'
/usr/bin/ld: src/libcomps.so.0: undefined reference to `expand4'
/usr/bin/ld: src/libcomps.so.0: undefined reference to `expand_s'
/usr/bin/ld: src/libcomps.so.0: undefined reference to `expand3'
/usr/bin/ld: src/libcomps.so.0: undefined reference to `expand5'
/usr/bin/ld: src/libcomps.so.0: undefined reference to `expand_out'
collect2: error: ld returned 1 exit status
[59/59] Linking C shared library src/python/src/libcomps/_libpycomps.so
ninja: build stopped: subcommand failed.
```

But patch I wrote fixes this and libcomps links as it should:
```
# ldd /usr/lib/libcomps.so.0                                                                                                                                                                                      
	ldd (0x7fb3dd2c8000)
	libexpat.so.1 => /lib/libexpat.so.1 (0x7fb3dd278000)
	libxml2.so.2 => /lib/libxml2.so.2 (0x7fb3dd170000)
	libc.so => ldd (0x7fb3dd2c8000)
	libz.so => /lib/libz.so (0x7fb3dd158000)
	liblzma.so.5 => /lib/liblzma.so.5 (0x7fb3dd138000)
```