### PR TITLE
Use already implemented clear for COMPS_HSList (RhBug:1888343)

### DIFF
--- a/libcomps/src/comps_objradix.c
+++ b/libcomps/src/comps_objradix.c
@@ -611,20 +611,9 @@ void comps_objrtree_unset(COMPS_ObjRTree * rt, const char * key) {
 }
 
 void comps_objrtree_clear(COMPS_ObjRTree * rt) {
-    COMPS_HSListItem *it, *oldit;
     if (rt==NULL) return;
-    if (rt->subnodes == NULL) return;
-    oldit = rt->subnodes->first;
-    it = (oldit)?oldit->next:NULL;
-    for (;it != NULL; it=it->next) {
-        comps_object_destroy(oldit->data);
-        free(oldit);
-        oldit = it;
-    }
-    if (oldit) {
-        comps_object_destroy(oldit->data);
-        free(oldit);
-    }
+    comps_hslist_clear(rt->subnodes);
+    rt->len = 0;
 }
 
 inline COMPS_HSList* __comps_objrtree_all(COMPS_ObjRTree * rt, char keyvalpair) {

--- a/libcomps/src/python/tests/__test.py
+++ b/libcomps/src/python/tests/__test.py
@@ -986,6 +986,16 @@ class COMPSTest(unittest.TestCase):
 
         _f([x.name for x in env.option_ids], option_ids)
 
+    #@unittest.skip("")
+    def test_clear_for_COMPS_ObjRTree_such_as_group_or_category_namy_by_lang(self):
+        comps = libcomps.Comps()
+        ret = comps.fromxml_f("comps/f21-rawhide-comps.xml")
+
+        env = comps.categories[0].name_by_lang.clear()
+        env = comps.groups[0].name_by_lang.clear()
+
+        self.assertEqual(str(comps.categories[0].name_by_lang), u'{}')
+        self.assertEqual(str(comps.groups[0].name_by_lang), u'{}')
 
     #@unittest.skip("")
     def test_xml_options(self):


### PR DESCRIPTION
Instead of reimplementing clear for `COMPS_HSList` use `comps_hslist_clear`.
The crash was caused by dangling pointers `first` and `last` in the
`COMPS_HSList` (rt->subnodes) struct, function `comps_hslist_clear` clears
them out properly.

= changelog =
msg: Fix a crash when clearing COMPS_ObjRTree
type: bugfix
resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1888343