### PR TITLE
Fix: resources leaks, check result "comps_parse_parsed_init()"

### DIFF
--- a/libcomps/src/comps_docenv.c
+++ b/libcomps/src/comps_docenv.c
@@ -349,11 +349,11 @@ signed char comps_docenv_xml(COMPS_DocEnv *env, xmlTextWriterPtr writer,
                 }
                 str = comps_object_tostr(((COMPS_ObjRTreePair*)hsit->data)->data);
                 ret = xmlTextWriterWriteString(writer, (xmlChar*)str);
+                free(str);
                 if (__comps_check_xml_get(ret, (COMPS_Object*)log) < 0) {
                     comps_hslist_destroy(&pairlist);
                     return -1;
                 }
-                free(str);
                 ret = xmlTextWriterEndElement(writer);
                 if (__comps_check_xml_get(ret, (COMPS_Object*)log) < 0) {
                     comps_hslist_destroy(&pairlist);

--- a/libcomps/src/comps_docpackage.c
+++ b/libcomps/src/comps_docpackage.c
@@ -196,8 +196,8 @@ signed char comps_docpackage_xml(COMPS_DocGroupPackage *pkg,
     COMPS_XMLRET_CHECK()
     str = comps_object_tostr((COMPS_Object*)pkg->name);
     ret = xmlTextWriterWriteString(writer, (xmlChar*)str);
-    COMPS_XMLRET_CHECK()
     free(str);
+    COMPS_XMLRET_CHECK()
     ret = xmlTextWriterEndElement(writer);
     COMPS_XMLRET_CHECK()
     return 0;

--- a/libcomps/src/comps_parse.c
+++ b/libcomps/src/comps_parse.c
@@ -76,6 +76,7 @@ unsigned comps_parse_parsed_init(COMPS_Parsed * parsed, const char * encoding,
         if (!parsed->text_buffer)
             comps_hslist_destroy(&parsed->text_buffer);
         COMPS_OBJECT_DESTROY(parsed->log);
+        XML_ParserFree(parsed->parser);
         free(parsed);
         return 0;
     }
@@ -218,6 +219,7 @@ signed char comps_parse_file(COMPS_Parsed *parsed, FILE *f,
         buff = XML_GetBuffer(parsed->parser, BUFF_SIZE);
         if (buff == NULL) {
             comps_log_error(parsed->log, COMPS_ERR_MALLOC, 0);
+            fclose(f);
             raise(SIGABRT);
             return -1;
         }

--- a/libcomps/src/python/src/pycomps.c
+++ b/libcomps/src/python/src/pycomps.c
@@ -228,7 +228,10 @@ PyObject* PyCOMPS_fromxml_f(PyObject *self, PyObject *args, PyObject* kwds) {
     }
 
     parsed = comps_parse_parsed_create();
-    comps_parse_parsed_init(parsed, "UTF-8", 0);
+    if (!comps_parse_parsed_init(parsed, "UTF-8", 0)) {
+        PyErr_SetString(PyCOMPSExc_ParserError, "Fatal error in comps_parse_parsed_init()");
+        return NULL;
+    }
     f =  fopen(fname, "r");
     if (!f) {
         PyErr_Format(PyExc_IOError, "Cannot open %s for reading", fname);
@@ -337,7 +340,10 @@ PyObject* PyCOMPS_fromxml_str(PyObject *self, PyObject *args, PyObject *kwds) {
 
     COMPS_Parsed *parsed;
     parsed = comps_parse_parsed_create();
-    comps_parse_parsed_init(parsed, "UTF-8", 0);
+    if (!comps_parse_parsed_init(parsed, "UTF-8", 0)) {
+        PyErr_SetString(PyCOMPSExc_ParserError, "Fatal error in comps_parse_parsed_init()");
+        return NULL;
+    }
     parsed_ret = comps_parse_str(parsed, tmps, options);
     if (options)
         free(options);

--- a/libcomps/tests/check_comps.c
+++ b/libcomps/tests/check_comps.c
@@ -523,7 +523,7 @@ START_TEST(test_comps_doc_union)
     COMPS_Parsed *parsed;
     FILE *fp;
     parsed = comps_parse_parsed_create();
-    comps_parse_parsed_init(parsed, "UTF-8", 0);
+    fail_if(comps_parse_parsed_init(parsed, "UTF-8", 0) == 0);
     fp = fopen("sample_comps.xml", "r");
     comps_parse_file(parsed, fp, NULL);
 
@@ -595,7 +595,7 @@ START_TEST(test_doc_defaults) {
     tmp = comps2xml_str(doc, NULL, NULL);
     //printf("tmp %s\n", tmp);
     parsed = comps_parse_parsed_create();
-    comps_parse_parsed_init(parsed, "UTF-8", 1);
+    fail_if(comps_parse_parsed_init(parsed, "UTF-8", 1) == 0);
     comps_parse_str(parsed, tmp, NULL);
     doc2 = parsed->comps_doc;
     groups = comps_doc_groups(doc2);

--- a/libcomps/tests/check_parse.c
+++ b/libcomps/tests/check_parse.c
@@ -72,7 +72,7 @@ START_TEST(test_comps_parse1)
     fprintf(stderr, "## Running test_parse1\n\n");
 
     parsed = comps_parse_parsed_create();
-    comps_parse_parsed_init(parsed, "UTF-8", 1);
+    fail_if(comps_parse_parsed_init(parsed, "UTF-8", 1) == 0);
 
 
     fp = fopen("sample-comps.xml", "r");
@@ -171,7 +171,7 @@ START_TEST(test_comps_parse1)
     comps_parse_parsed_destroy(parsed);
 
     parsed = comps_parse_parsed_create();
-    comps_parse_parsed_init(parsed, "UTF-8", 1);
+    fail_if(comps_parse_parsed_init(parsed, "UTF-8", 1) == 0);
     comps_parse_file(parsed, fp, NULL);
     ret = comps_parse_validate_dtd("sample-bad-elem.xml", "comps.dtd");
     fail_if(ret >0, "XML shouldn't be valid. Validation returned: %d", ret);
@@ -280,7 +280,7 @@ START_TEST(test_comps_parse2)
     //                                         COMPS_ERR_ELEM_REQUIRED, 1201, 2, 0);
 
     parsed = comps_parse_parsed_create();
-    comps_parse_parsed_init(parsed, "UTF-8", 1);
+    fail_if(comps_parse_parsed_init(parsed, "UTF-8", 1) == 0);
     fp = fopen("sample_comps.xml", "r");
     comps_parse_file(parsed, fp, NULL);
 
@@ -320,7 +320,7 @@ START_TEST(test_comps_parse3)
                                              comps_num(188), comps_num(2));
 
     parsed = comps_parse_parsed_create();
-    comps_parse_parsed_init(parsed, "UTF-8", 1);
+    fail_if(comps_parse_parsed_init(parsed, "UTF-8", 1) == 0);
     fp = fopen("sample_comps_bad1.xml", "r");
     comps_parse_file(parsed, fp, NULL);
 
@@ -413,7 +413,7 @@ START_TEST(test_comps_parse4)
                                      comps_num(1244), comps_num(4));
 
     parsed = comps_parse_parsed_create();
-    comps_parse_parsed_init(parsed, "UTF-8", 1);
+    fail_if(comps_parse_parsed_init(parsed, "UTF-8", 1) == 0);
     fp = fopen("sample_comps_bad2.xml", "r");
     comps_parse_file(parsed, fp, NULL);
 
@@ -446,7 +446,7 @@ START_TEST(test_comps_parse5)
                                     comps_num(2));
 
     parsed = comps_parse_parsed_create();
-    comps_parse_parsed_init(parsed, "UTF-8", 1);
+    fail_if(comps_parse_parsed_init(parsed, "UTF-8", 1) == 0);
     fp = fopen("sample_comps_bad3.xml", "r");
     comps_parse_file(parsed, fp, NULL);
     //comps_log_print(parsed->log);
@@ -472,7 +472,7 @@ START_TEST(test_comps_fedora_parse)
     //char *tmp;
     fprintf(stderr, "## Running test_parse fedora\n");
     parsed = comps_parse_parsed_create();
-    comps_parse_parsed_init(parsed, "UTF-8", 0);
+    fail_if(comps_parse_parsed_init(parsed, "UTF-8", 0) == 0);
     fp = fopen("fedora_comps.xml", "r");
     comps_parse_file(parsed, fp, NULL);
     //printf("log len:%d\n", parsed->log->logger_data->len);
@@ -501,7 +501,7 @@ START_TEST(test_main2)
     //char *tmp;
     fprintf(stderr, "## Running test_parse main2\n");
     parsed = comps_parse_parsed_create();
-    comps_parse_parsed_init(parsed, "UTF-8", 0);
+    fail_if(comps_parse_parsed_init(parsed, "UTF-8", 0) == 0);
     fp = fopen("main_comps2.xml", "r");
     comps_parse_file(parsed, fp, NULL);
     fail_if(parsed->fatal_error != 0, "Some fatal errors found after parsing");
@@ -550,7 +550,7 @@ START_TEST(test_arch)
     //char *tmp;
     fprintf(stderr, "## Running test_parse arch\n");
     parsed = comps_parse_parsed_create();
-    comps_parse_parsed_init(parsed, "UTF-8", 0);
+    fail_if(comps_parse_parsed_init(parsed, "UTF-8", 0) == 0);
     fp = fopen("main_arches.xml", "r");
     comps_parse_file(parsed, fp, NULL);
     //comps_log_print(parsed->log);

--- a/libcomps/tests/check_validate.c
+++ b/libcomps/tests/check_validate.c
@@ -132,7 +132,7 @@ START_TEST(test_doc_validate) {
 
     fp = fopen("f21-rawhide-comps.xml", "r");
     parsed = comps_parse_parsed_create();
-    comps_parse_parsed_init(parsed, "UTF-8", 0);
+    fail_if(comps_parse_parsed_init(parsed, "UTF-8", 0) != 1);
     comps_parse_file(parsed, fp, NULL);
     doc = parsed->comps_doc;
     result = comps_validate_execute((COMPS_Object*)doc, COMPS_Doc_ValidateRules);


### PR DESCRIPTION
The bugs were found during review of important potential issues detected by static analyzers.
https://bugzilla.redhat.com/show_bug.cgi?id=1938759