### PR TITLE
Don't print empty requires

### DIFF
--- a/libcomps/src/comps_docpackage.c
+++ b/libcomps/src/comps_docpackage.c
@@ -169,8 +169,9 @@ signed char comps_docpackage_xml(COMPS_DocGroupPackage *pkg,
 
     if (pkg->requires) {
         str = comps_object_tostr((COMPS_Object*)pkg->requires);
-        ret = xmlTextWriterWriteAttribute(writer, (xmlChar*) "requires",
-                                            BAD_CAST str);
+        if (str && *str) {
+            ret = xmlTextWriterWriteAttribute(writer, (xmlChar*) "requires", BAD_CAST str);
+        }
         free(str);
     }
     COMPS_XMLRET_CHECK()

--- a/libcomps/src/python/tests/__test.py
+++ b/libcomps/src/python/tests/__test.py
@@ -626,7 +626,7 @@ class PackageTest(unittest.TestCase):
         self.comps.groups[0].packages.append(libcomps.Package("kernel", libcomps.PACKAGE_TYPE_MANDATORY))
 
         out = self.comps.xml_str()
-        self.assertTrue("<packagereq type=\"mandatory\" requires=\"\">kernel</packagereq>" in out)
+        self.assertTrue("<packagereq type=\"mandatory\">kernel</packagereq>" in out)
 
 #@unittest.skip("skip")
 class DictTest(unittest.TestCase):


### PR DESCRIPTION
The function `comps_object_tostr` used to get the string returns either
a valid value or if there is none it returns allocated "0" char.

Closes: https://github.com/rpm-software-management/libcomps/issues/23