### PR TITLE
Python2 syntax is deprecated and will be removed in Sphinx 4.0

### DIFF
--- a/libcomps/src/python/docs/doc-sources/conf.py.in
+++ b/libcomps/src/python/docs/doc-sources/conf.py.in
@@ -20,7 +20,7 @@ import sys, os
 import ctypes
 clibcomps = ctypes.cdll.LoadLibrary("@LIBCOMPS_OUT@/libcomps.so.@libcomps_VERSION_MAJOR@")
 os.environ['LD_LIBRARY_PATH'] = "%s" % "@LIBCOMPS_OUT@"
-print os.environ['LD_LIBRARY_PATH']
+print(os.environ['LD_LIBRARY_PATH'])
 
 sys.path.insert(0, os.path.abspath("@PYCOMPS_LIB_PATH@"))
 import libcomps


### PR DESCRIPTION
For: https://github.com/rpm-software-management/libcomps/issues/83