### PR TITLE
Rework the release CI to require less maintainence

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -1,53 +1,86 @@
 ---
-name: Python Release
+name: Release to PyPI
 
 on:
   release:
     types: [created]
 
 jobs:
-  release:
-    name: PyPI Release
+  build_sdist:
+    name: Build source package
     runs-on: ubuntu-latest
     container: fedora:latest
     steps:
     - uses: actions/checkout@v2
 
-    - name: Install dependencies
+    - name: Install / upgrade dependencies
       run: |
-        sudo dnf -y install dnf-plugins-core
+        sudo dnf -y install dnf-plugins-core python3-pip
         sudo dnf -y builddep libcomps.spec
-        pip install --upgrade pip
-        pip install pytest twine scikit-build
+        python3 -m pip install --upgrade pip scikit-build
 
-    - name: Build Python sdist
-      run: python3 setup.py sdist
+    - name: Build and install Python source package
+      run: |
+        python3 setup.py sdist
+        python3 -m pip install dist/*.tar.gz
 
-    - name: Build manylinux Python wheels
-      uses: RalfG/python-wheels-manylinux-build@v0.3.3-manylinux2014_x86_64
+    - name: Run tests
+      run: |
+        python3 -m pip install pytest
+        pushd libcomps/src/python/tests/
+        pytest --verbose --color=yes ./
+        popd
+
+    - uses: actions/upload-artifact@v2
       with:
-        python-versions: 'cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39'
-        build-requirements: 'scikit-build'
-        system-packages: 'make cmake bzip2-devel expat-devel libxml2-devel xz-devel'
+        path: dist/*.tar.gz
 
-    - name: Install and Test Python source package
-      run: |
-        pip install --user dist/*.tar.gz
-        pushd libcomps/src/python/tests/
-        pytest --verbose --color=yes ./
-        popd
 
-    - name: Install and Test Python universal binary wheel package
-      run: |
-        pip install --user dist/libcomps-*-cp39-cp39-manylinux2014_x86_64.whl
-        pushd libcomps/src/python/tests/
-        pytest --verbose --color=yes ./
-        popd
+  build_bdist:
+    name: Build binary wheels
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
 
-    - name: Publish packages to PyPI
+    # setup Python for cibuildwheel
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    # for other architectures, see: https://cibuildwheel.readthedocs.io/en/stable/faq/#emulation
+    - name: Build wheels for CPython
+      uses: pypa/cibuildwheel@v2.1.1
       env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{secrets.PYPI_API_TOKEN}}
-      run: |
-        twine upload dist/*.tar.gz
-        twine upload wheelhouse/*-manylinux*.whl
+        CIBW_ARCHS: auto64  # only 64-bit
+        CIBW_SKIP: "pp*"  # no PyPy builds
+        CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014  # centos 7
+        CIBW_BEFORE_ALL: yum install -y make cmake bzip2-devel expat-devel libxml2-devel xz-devel
+        CIBW_BEFORE_BUILD: python -m pip install scikit-build
+        CIBW_TEST_REQUIRES: pytest
+        CIBW_TEST_COMMAND: |
+          pushd {project}/libcomps/src/python/tests/
+          pytest --verbose --color=yes ./
+          popd
+
+    - uses: actions/upload-artifact@v2
+      with:
+        path: ./wheelhouse/*.whl
+
+
+  upload_pypi:
+    name: Publish packages to PyPI
+    # only publish packages once everything is successful
+    needs: [build_bdist, build_sdist]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: artifact
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@v1.4.2
+        with:
+          user: __token__
+          password: ${{secrets.PYPI_API_TOKEN}}
+          # To test: repository_url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Use official "actions" for building and publishing packages. Do the
uploading in a separate job. Run tests on each binary wheel built.
Get rid of hardcoded strings