### PR TITLE
Fix non-optimized builds by removing `inline` keyword

### DIFF
--- a/libcomps/src/comps_log_codes.c
+++ b/libcomps/src/comps_log_codes.c
@@ -1,6 +1,6 @@
 #include "comps_log_codes.h"
 
-inline void __expand(char *str, const char *fmt, char out, ...) {
+void __expand(char *str, const char *fmt, char out, ...) {
     va_list list;
     (void) str;
     va_start(list, out);
@@ -9,6 +9,41 @@ inline void __expand(char *str, const char *fmt, char out, ...) {
     else
         vsprintf(str, fmt, list);
     va_end(list);
+}
+
+void expand0(char *str, const char *fmt, char **args, char out) {
+    (void)args;
+    __expand(str, fmt, out);
+}
+
+void expand1(char *str, const char *fmt, char **args, char out) {
+    __expand(str, fmt, out, args[0]);
+}
+
+void expand2(char *str, const char *fmt, char **args, char out) {
+    __expand(str, fmt, out, args[0],
+                          args[1]);
+}
+
+void expand3(char *str, const char *fmt, char **args, char out) {
+    __expand(str, fmt, out, args[0],
+                           args[1],
+                           args[2]);
+}
+
+void expand4(char *str, const char *fmt, char **args, char out) {
+    __expand(str, fmt, out, args[0],
+                           args[1],
+                           args[2],
+                           args[3]);
+}
+
+void expand5(char *str, const char *fmt, char **args, char out) {
+    __expand(str, fmt, out, args[0],
+                           args[1],
+                           args[2],
+                           args[3],
+                           args[4]);
 }
 
 void expand(char *str, const char *fmt, char **args, int len, int out) {
@@ -34,4 +69,12 @@ void expand(char *str, const char *fmt, char **args, int len, int out) {
         default:
         break;
     }
+}
+
+void expand_out(const char *fmt, char **args, int len) {
+    expand(NULL, fmt, args, len, 1);
+}
+
+void expand_s(char *str, const char *fmt, char **args, int len) {
+    expand(str, fmt, args, len, 0);
 }

--- a/libcomps/src/comps_log_codes.h
+++ b/libcomps/src/comps_log_codes.h
@@ -48,43 +48,16 @@
 
 void __expand(char *str, const char *fmt, char out, ...);
 
-inline void expand0(char *str, const char *fmt, char **args, char out) {
-    (void)args;
-    __expand(str, fmt, out);
-}
-inline void expand1(char *str, const char *fmt, char **args, char out) {
-    __expand(str, fmt, out, args[0]);
-}
-inline void expand2(char *str, const char *fmt, char **args, char out) {
-    __expand(str, fmt, out, args[0],
-                          args[1]);
-}
-inline void expand3(char *str, const char *fmt, char **args, char out) {
-    __expand(str, fmt, out, args[0],
-                           args[1],
-                           args[2]);
-}
-inline void expand4(char *str, const char *fmt, char **args, char out) {
-    __expand(str, fmt, out, args[0],
-                           args[1],
-                           args[2],
-                           args[3]);
-}
-inline void expand5(char *str, const char *fmt, char **args, char out) {
-    __expand(str, fmt, out, args[0],
-                           args[1],
-                           args[2],
-                           args[3],
-                           args[4]);
-}
+void expand0(char *str, const char *fmt, char **args, char out);
+void expand1(char *str, const char *fmt, char **args, char out);
+void expand2(char *str, const char *fmt, char **args, char out);
+void expand3(char *str, const char *fmt, char **args, char out);
+void expand4(char *str, const char *fmt, char **args, char out);
+void expand5(char *str, const char *fmt, char **args, char out);
 
 void expand(char *str, const char *fmt, char **args, int len, int out);
 
-inline void expand_out(const char *fmt, char **args, int len) {
-    expand(NULL, fmt, args, len, 1);
-}
-inline void expand_s(char *str, const char *fmt, char **args, int len) {
-    expand(str, fmt, args, len, 0);
-}
+void expand_out(const char *fmt, char **args, int len);
+void expand_s(char *str, const char *fmt, char **args, int len);
 
 #endif


### PR DESCRIPTION
The raw (without `static` or `extern`) `inline` keyword defines an
alternative version of a functions that is used when inlining.
When optimizations are turned off (eg when `-DCMAKE_BUILD_TYPE=Debug`)
it wants to use the original version of the function but there is no such
definition -> linking fails.

To fix this and preserve API remove the `inline` keyword and define the
functions normally.