### PR TITLE
libcomps: Use Py_hash_t instead of long in PyCOMPS_hash()

### DIFF
--- a/libcomps/src/python/src/pycomps_hash.c
+++ b/libcomps/src/python/src/pycomps_hash.c
@@ -20,9 +20,9 @@
 #include "pycomps_hash.h"
 #include "pycomps_utils.h"
 
-long PyCOMPS_hash(PyObject *self) {
+Py_hash_t PyCOMPS_hash(PyObject *self) {
     char *cstr = NULL;
-    long crc;
+    Py_hash_t crc;
 
     cstr = comps_object_tostr(((PyCompsObject*)self)->c_obj);
     crc = crc32(0, cstr, strlen(cstr));

--- a/libcomps/src/python/src/pycomps_hash.h
+++ b/libcomps/src/python/src/pycomps_hash.h
@@ -26,6 +26,6 @@
 #include "pycomps_utils.h"
 
 
-long PyCOMPS_hash(PyObject *self);
+Py_hash_t PyCOMPS_hash(PyObject *self);
 
 #endif

--- a/libcomps/src/python/src/pycomps_utils.h
+++ b/libcomps/src/python/src/pycomps_utils.h
@@ -137,7 +137,7 @@ COMPS_Object* __pycomps_bytes_in(PyObject *pobj);
 PyObject* __pycomps_str_out(COMPS_Object *obj);
 PyObject *str_to_unicode(void* str);
 
-long PyCOMPS_hash(PyObject *self);
+Py_hash_t PyCOMPS_hash(PyObject *self);
 
 PyObject* PyCOMPSSeq_extra_get(PyObject *self, PyObject *key);
 


### PR DESCRIPTION
This function is used as a hashfunc callback in
_typeobject defined python3.11/cpython/object.h
compilers detect the protype mismatch for function pointers with clang16+

Fixes
libcomps/src/python/src/pycomps_sequence.c:667:5: error: incompatible function pointer types initializing 'hashfunc' (aka 'int (*)(struct _object *)') with an expression of type 'long (*)(PyObject *)' (aka 'long (*)(struct _object *)') [-Wincompatible-function-pointer-types]
    &PyCOMPS_hash,             /*tp_hash */