### PR TITLE
Move return value check right after parser call for `fromxml_str()`

### DIFF
--- a/libcomps/src/python/src/pycomps.c
+++ b/libcomps/src/python/src/pycomps.c
@@ -347,6 +347,11 @@ PyObject* PyCOMPS_fromxml_str(PyObject *self, PyObject *args, PyObject *kwds) {
     parsed_ret = comps_parse_str(parsed, tmps, options);
     if (options)
         free(options);
+    if (parsed_ret == -1) {
+        comps_parse_parsed_destroy(parsed);
+        PyErr_SetString(PyCOMPSExc_ParserError, "Fatal parser error");
+        return NULL;
+    }
     Py_CLEAR(self_comps->p_groups);
     Py_CLEAR(self_comps->p_categories);
     Py_CLEAR(self_comps->p_environments);
@@ -361,10 +366,6 @@ PyObject* PyCOMPS_fromxml_str(PyObject *self, PyObject *args, PyObject *kwds) {
     parsed->log = NULL;
     parsed->comps_doc = NULL;
     comps_parse_parsed_destroy(parsed);
-    if (parsed_ret == -1) {
-        PyErr_SetString(PyCOMPSExc_ParserError, "Fatal parser error");
-        return NULL;
-    }
 
     return PyLong_FromLong((long)parsed_ret);
 }

--- a/libcomps/src/python/tests/__test.py
+++ b/libcomps/src/python/tests/__test.py
@@ -718,23 +718,24 @@ class COMPSTest(unittest.TestCase):
         ret = comps2.fromxml_f(fname)
         self.assertTrue(ret == 0, comps2.get_last_errors())
 
-        compsdoc = comps2.xml_str()
-        compsdoc = compsdoc[0:-5] # make some error
         self.assertTrue(len(comps2.groups) == 3)
         self.assertTrue(len(comps2.categories) == 2)
         self.assertTrue(len(comps2.environments) == 0)
 
-        comps3 = libcomps.Comps()
-        self.assertRaises(libcomps.ParserError, comps3.fromxml_str, compsdoc)
-
-        self.assertTrue(len(comps3.groups) == 3)
-        self.assertTrue(len(comps3.categories) == 2)
-        self.assertTrue(len(comps3.environments) == 0)
         x = self.comps.xml_str(xml_options={})
         y = comps2.xml_str()
 
         self.assertTrue(x == y)
         os.remove(fname)
+
+        compsdoc = comps2.xml_str()
+        compsdoc = compsdoc[0:-5] # make some error
+        comps3 = libcomps.Comps()
+        self.assertRaises(libcomps.ParserError, comps3.fromxml_str, compsdoc)
+
+        INVALID_COMPS_XML = "invalid xml"
+        comps4 = libcomps.Comps()
+        self.assertRaises(libcomps.ParserError, comps4.fromxml_str, str(INVALID_COMPS_XML))
 
     #@unittest.skip("")
     def test_fedora(self):


### PR DESCRIPTION
For: https://github.com/rpm-software-management/libcomps/issues/103