### PR TITLE
build: Restore compatiblity with libxml2-2.12.0

### DIFF
--- a/libcomps/src/comps_doc.c
+++ b/libcomps/src/comps_doc.c
@@ -25,6 +25,7 @@
 
 #include <stdio.h>
 #include <assert.h>
+#include <libxml/parser.h>
 static signed char comps_doc_xml(COMPS_Doc *doc, xmlTextWriterPtr writer,
                                  COMPS_XMLOptions *xml_options,
                                  COMPS_DefaultsOptions *def_options);


### PR DESCRIPTION
fail: https://copr.fedorainfracloud.org/coprs/rpmsoftwaremanagement/dnf-nightly/build/6668780/
pass: https://copr.fedorainfracloud.org/coprs/nsella/dnf5_stack_fix_xml/build/6670489/