### PR TITLE
libcomps: Support builds with CMake 4+

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ for python bindings:
 
 for C library tests:
 
-*   check http://check.sourceforge.net/
+*   check https://github.com/libcheck/check
 
 for documentation build:
 
@@ -128,4 +128,3 @@ Here's the most direct way to get your work merged into the project.
 
 1. Push the branch to your fork
 1. Send a pull request for your branch
-

--- a/libcomps/CMakeLists.txt
+++ b/libcomps/CMakeLists.txt
@@ -1,5 +1,8 @@
+cmake_minimum_required (VERSION 3.10)
 project(libcomps C)
-cmake_minimum_required (VERSION 2.8.10)
+
+cmake_policy(SET CMP0148 OLD)
+cmake_policy(SET CMP0175 NEW)
 
 include (GNUInstallDirs)
 include (${CMAKE_ROOT}/Modules/CheckFunctionExists.cmake)
@@ -32,7 +35,7 @@ include_directories("${PROJECT_SOURCE_DIR}/src")
 #include_directories("${PROJECT_SOURCE_DIR}/src/libcomps")
 
 if (ENABLE_TESTS)
-  find_library(CHECK_LIBRARY NAMES check)
+  find_library(CHECK_LIBRARY REQUIRED NAMES check)
 endif()
 find_library(EXPAT_LIBRARY NAMES expat)
 

--- a/libcomps/src/python/docs/CMakeLists.txt
+++ b/libcomps/src/python/docs/CMakeLists.txt
@@ -26,7 +26,8 @@ add_dependencies(pydocs pycomps)
 include(../pycopy.cmake)
 add_custom_command(TARGET pydocs PRE_BUILD COMMAND set -E $ENV{LD_LIBRARY_PATH} "${LIBCOMPS_OUT}:$ENV{LD_LIBRARY_PATH}")
 
-add_custom_command(TARGET pydocs COMMAND ${PYTHON_EXECUTABLE} ${SPHINX_EXECUTABLE} -E -b html
+add_custom_command(TARGET pydocs POST_BUILD
+                                 COMMAND ${PYTHON_EXECUTABLE} ${SPHINX_EXECUTABLE} -E -b html
                                   "${CMAKE_CURRENT_SOURCE_DIR}/doc-sources/"
                                   "${CMAKE_CURRENT_BINARY_DIR}/html/"
                                  COMMENT "LDLP $ENV{LD_LIBRARY_PATH}")

--- a/libcomps/src/python/pycopy.cmake
+++ b/libcomps/src/python/pycopy.cmake
@@ -6,9 +6,10 @@ math (EXPR len "${len} - 1")
 
 #set(pycopy "py${pversion}-copy")
 
-#if (NOT TARGET ${pycopy})
+if (NOT TARGET ${pycopy})
+    add_custom_target(${pycopy} DEPENDS pycomps)
+endif()
 
-#add_custom_target(${pycopy} DEPENDS pycomps)
 set (pycomps_SRCDIR "${PROJECT_SOURCE_DIR}/src/python/src/")
 set (pycomps_TESTDIR "${PROJECT_SOURCE_DIR}/src/python/tests/")
 set (pycomps_LIBPATH ${PYCOMPS_LIB_PATH})#"${PROJECT_BINARY_DIR}/src/python/src/python${pversion}")
@@ -16,7 +17,7 @@ set (pycomps_LIBPATH ${PYCOMPS_LIB_PATH})#"${PROJECT_BINARY_DIR}/src/python/src/
 #add_custom_command(TARGET pycopy PRE_BUILD COMMAND ${CMAKE_COMMAND} -E
 #                    make_directory "${CP_DST}")
 
-add_custom_command(TARGET ${pycopy} COMMAND ${CMAKE_COMMAND} -E
+add_custom_command(TARGET ${pycopy} POST_BUILD COMMAND ${CMAKE_COMMAND} -E
                     make_directory ${pycomps_LIBPATH}/libcomps/comps/)
 
 foreach(x RANGE 0 ${len})

--- a/libcomps/tests/CMakeLists.txt
+++ b/libcomps/tests/CMakeLists.txt
@@ -87,7 +87,5 @@ add_custom_target(test_parse_run
                    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                    DEPENDS test_parse
                    COMMENT "Running comps_parse test")
-target_link_libraries(test_parse_run libcomps)
-target_link_libraries(test_comps_run libcomps)
 
 add_dependencies(ctest test_comps_run test_parse_run)


### PR DESCRIPTION
- Bump minimum required version to 3.10, the lowest one CMake 4+ don't complain
  about. It's also possible to use 3.5, but that results in a deprecation
  warning. The 'cmake_minimum_required()' invocation has been moved before the
  initial 'project()' call as CMake complained about the wrong order.

- Set policy CMP0148 [0] to OLD to unblock build without additional changes.
  Eventually, the usage of the 'PythonInterp' and 'PythonLibs' find modules will
  be need to be updated to use 'Python3' instead.

- Set policy CMP0175 [1] to NEW and fix warnings.

- Fix the 'No TARGET ... has been created in this directory' error in
  'src/python'.

- Fix 'Utility target <foo> must not be used as the target of a
  target_link_libraries call' errors (see [2]).

- Mark the 'check' library as required when tests are enabled to prevent test
  targets from linking a non-existing library in case it's not installed.

[0]: https://cmake.org/cmake/help/latest/policy/CMP0148.html
[1]: https://cmake.org/cmake/help/latest/policy/CMP0175.html
[2]: https://cmake.org/cmake/help/latest/policy/CMP0039.html

Fixes #118