### PR TITLE
spec: Update cmake version and patch application

### DIFF
--- a/libcomps.spec
+++ b/libcomps.spec
@@ -10,7 +10,7 @@ URL:            https://github.com/rpm-software-management/libcomps
 Source0:        %{url}/archive/%{version}/%{name}-%{version}.tar.gz
 
 BuildRequires:  gcc-c++
-BuildRequires:  cmake
+BuildRequires:  cmake >= 3.10
 BuildRequires:  gcc
 BuildRequires:  libxml2-devel
 BuildRequires:  check-devel
@@ -60,7 +60,7 @@ Obsoletes:      platform-python-%{name} < %{version}-%{release}
 Python3 bindings for libcomps library.
 
 %prep
-%autosetup -n %{name}-%{version}
+%autosetup -p1 -n %{name}-%{version}
 
 mkdir build-py3
 mkdir build-doc


### PR DESCRIPTION
CMake minimal version was changed in
702ec1423fb9b53244b902923fd87ef19b63a7f5 commit (libcomps: Support builds with CMake 4+), but the spec file was not updated.

Also the spec file was missing -p1 argument at %autosetup macro which is already used in Fedora and is handy when applying git-generated patches.