### PR TITLE
build: Enable CMP0175 since CMake 3.31

### DIFF
--- a/libcomps/CMakeLists.txt
+++ b/libcomps/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required (VERSION 3.10)
 project(libcomps C)
 
 cmake_policy(SET CMP0148 OLD)
+if ("${CMAKE_VERSION}" VERSION_GREATER_EQUAL "3.31")
 cmake_policy(SET CMP0175 NEW)
+endif()
 
 include (GNUInstallDirs)
 include (${CMAKE_ROOT}/Modules/CheckFunctionExists.cmake)


### PR DESCRIPTION
Building with cmake 3.30.8 failed:

    CMake Error at CMakeLists.txt:5 (cmake_policy):
      Policy "CMP0175" is not known to this version of CMake.

The cause is that CMP0175 is available since 3.31. It was added in commit 702ec1423fb9b53244b902923fd87ef19b63a7f5 (libcomps: Support builds with CMake 4+).

Because it only enables new warnings, make it optional so that we can build with older CMakes.

Resolve: https://bugzilla.redhat.com/show_bug.cgi?id=2388825