### PR TITLE
docs: do not use full file paths in generated doxygen docs

### DIFF
--- a/libcomps/docs/Doxyfile.user.in
+++ b/libcomps/docs/Doxyfile.user.in
@@ -119,7 +119,7 @@ INLINE_INHERITED_MEMB  = NO
 # path before files name in the file list and in the header files. If set
 # to NO the shortest path that makes the file name unique will be used.
 
-FULL_PATH_NAMES        = YES
+FULL_PATH_NAMES        = NO
 
 # If the FULL_PATH_NAMES tag is set to YES then the STRIP_FROM_PATH tag
 # can be used to strip a user-defined part of the path. Stripping is

--- a/libcomps/src/python/docs/Doxyfile.user.in
+++ b/libcomps/src/python/docs/Doxyfile.user.in
@@ -119,7 +119,7 @@ INLINE_INHERITED_MEMB  = NO
 # path before files name in the file list and in the header files. If set
 # to NO the shortest path that makes the file name unique will be used.
 
-FULL_PATH_NAMES        = YES
+FULL_PATH_NAMES        = NO
 
 # If the FULL_PATH_NAMES tag is set to YES then the STRIP_FROM_PATH tag
 # can be used to strip a user-defined part of the path. Stripping is


### PR DESCRIPTION
Full build time file paths are not relevant for shipped documentation, and break reproducible builds, as they change depending on where the build is ran from.
Configure doxygen to use the minimal unique paths
instead, so that the leading directories are truncated.