### PR TITLE
style: cleanup `ver-bump.py`

### DIFF
--- a/ver-bump.py
+++ b/ver-bump.py
@@ -4,9 +4,8 @@ import sys
 import string
 
 if __name__ == "__main__":
-    f = open("version.json", "r")
-    version = json.load(f)
-    f.close()
+    with open("version.json", "r", encoding="utf-8") as f:
+        version = json.load(f)
     try:
         if sys.argv[1] == "major":
             version["libcomps_VERSION_MAJOR"] += 1
@@ -21,19 +20,15 @@ if __name__ == "__main__":
             version["libcomps_VERSION_PATCH"] += 1
             version["libcomps_RELEASE"] = 1
     except IndexError:
-            version["libcomps_VERSION_PATCH"] += 1
-            version["libcomps_RELEASE"] = 1
+        version["libcomps_VERSION_PATCH"] += 1
+        version["libcomps_RELEASE"] = 1
 
-    f = open("version.json", "w")
-    json.dump(version, f, indent=4)
-    f.close()
+    with open("version.json", "w", encoding="utf-8") as f:
+        json.dump(version, f, indent=4)
 
-    f = open("libcomps/version.cmake.in", "r")
-    version_in = f.read()
-    f.close()
+    with open("libcomps/version.cmake.in", "r", encoding="utf-8") as f:
+        version_in = f.read()
 
     version_out = string.Template(version_in).substitute(version)
-    f = open("libcomps/version.cmake", "w")
-    f.write(version_out)
-    f.close()
-
+    with open("libcomps/version.cmake", "w", encoding="utf-8") as f:
+        f.write(version_out)


### PR DESCRIPTION
Resolves the following pylints:
- bad-indentation / W0311
- consider-using-with / R1732
- unspecified-encoding / W1514