### PR TITLE
style: remove dead code from `comps_docpackage_xml`

### DIFF
--- a/libcomps/src/comps_docpackage.c
+++ b/libcomps/src/comps_docpackage.c
@@ -185,13 +185,8 @@ signed char comps_docpackage_xml(COMPS_DocGroupPackage *pkg,
         }
     } else {
         if (pkg->basearchonly && pkg->basearchonly->val != bao_def) {
-            if (pkg->basearchonly) {
-                ret = xmlTextWriterWriteAttribute(writer, (xmlChar*) "basearchonly",
-                                                    BAD_CAST "true");
-            } else {
-                ret = xmlTextWriterWriteAttribute(writer, (xmlChar*) "basearchonly",
-                                                    BAD_CAST "false");
-            }
+            ret = xmlTextWriterWriteAttribute(writer, (xmlChar*) "basearchonly",
+                                                BAD_CAST "true");
         }
     }
     COMPS_XMLRET_CHECK()


### PR DESCRIPTION
Note that `pkg->basearchonly` evaluates to `true` in this branch anyway. However, please be careful with merging - it might be a sign of some deeper bug.