### PR TITLE
fix: `COMPS_ElemInfo.attributes` have to be `NULL`-terminated

### DIFF
--- a/libcomps/src/comps_elem.c
+++ b/libcomps/src/comps_elem.c
@@ -57,7 +57,8 @@ const COMPS_ElemInfo COMPS_NAME_ElemInfo = {
                                           COMPS_ELEM_CATEGORY,
                                           COMPS_ELEM_ENV,
                                           COMPS_ELEM_SENTINEL},
-    .attributes = (const COMPS_ElemAttrInfo*[]){&COMPS_XMLLANG_ElemAttrInfo},
+    .attributes = (const COMPS_ElemAttrInfo*[]){&COMPS_XMLLANG_ElemAttrInfo,
+                                                NULL},
     .preproc = NULL,//&comps_elem_name_preproc,
     .postproc = &comps_elem_idnamedesc_postproc
 };
@@ -67,7 +68,8 @@ const COMPS_ElemInfo COMPS_DESC_ElemInfo = {
                                           COMPS_ELEM_CATEGORY,
                                           COMPS_ELEM_ENV,
                                           COMPS_ELEM_SENTINEL},
-    .attributes = (const COMPS_ElemAttrInfo*[]){&COMPS_XMLLANG_ElemAttrInfo},
+    .attributes = (const COMPS_ElemAttrInfo*[]){&COMPS_XMLLANG_ElemAttrInfo,
+                                                NULL},
     .preproc = NULL,//&comps_elem_desc_preproc,
     .postproc = &comps_elem_idnamedesc_postproc
 };


### PR DESCRIPTION
When executing all of the tests  the address sanitizer reports `global-buffer-overflow`:
<details>
  <summary>address sanitizer output</summary>

```
## Running test_parse1
=================================================================
==44258==ERROR: AddressSanitizer: global-buffer-overflow on address 0x7f13abd5e0a8 at pc 0x7f13abd45b4f bp 0x7ffc12f2d4f0 sp 0x7ffc12f2d4e0
READ of size 8 at 0x7f13abd5e0a8 thread T0
    #0 0x7f13abd45b4e in comps_parse_check_attributes /workspace/libcomps/libcomps/src/comps_parse.c:445
    #1 0x7f13abd46164 in comps_parse_start_elem_handler /workspace/libcomps/libcomps/src/comps_parse.c:391
    #2 0x7f13abcd64e3  (/lib/x86_64-linux-gnu/libexpat.so.1+0xa4e3)
    #3 0x7f13abcd76fc  (/lib/x86_64-linux-gnu/libexpat.so.1+0xb6fc)
    #4 0x7f13abcd9e32  (/lib/x86_64-linux-gnu/libexpat.so.1+0xde32)
    #5 0x7f13abcdaf0b  (/lib/x86_64-linux-gnu/libexpat.so.1+0xef0b)
    #6 0x7f13abcd04fe  (/lib/x86_64-linux-gnu/libexpat.so.1+0x44fe)
    #7 0x7f13abcdd486 in XML_ParseBuffer (/lib/x86_64-linux-gnu/libexpat.so.1+0x11486)
    #8 0x7f13abd44fc2 in comps_parse_file /workspace/libcomps/libcomps/src/comps_parse.c:229
    #9 0x55635b1dfb5c in test_comps_parse1_fn /workspace/libcomps/libcomps/tests/check_parse.c:79
    #10 0x7f13abcc5896 in tcase_run_tfun_fork /workspace/libcomps/check/src/check_run.c:497
    #11 0x7f13abcc5896 in srunner_iterate_tcase_tfuns /workspace/libcomps/check/src/check_run.c:256
    #12 0x7f13abcc5896 in srunner_run_tcase /workspace/libcomps/check/src/check_run.c:402
    #13 0x7f13abcc5896 in srunner_iterate_suites /workspace/libcomps/check/src/check_run.c:222
    #14 0x7f13abcc5896 in srunner_run_tagged /workspace/libcomps/check/src/check_run.c:814
    #15 0x55635b1dc966 in main /workspace/libcomps/libcomps/tests/check_parse.c:668
    #16 0x7f13ab7d8d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)
    #17 0x7f13ab7d8e3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f)
    #18 0x55635b1dca14 in _start (/workspace/libcomps/build/tests/test_parse+0x5a14)

0x7f13abd5e0a8 is located 56 bytes to the left of global variable '__compound_literal.5' defined in '/workspace/libcomps/libcomps/src/comps_elem.c:39:48' (0x7f13abd5e0e0) of size 16
0x7f13abd5e0a8 is located 0 bytes to the right of global variable '__compound_literal.9' defined in '/workspace/libcomps/libcomps/src/comps_elem.c:60:48' (0x7f13abd5e0a0) of size 8
SUMMARY: AddressSanitizer: global-buffer-overflow /workspace/libcomps/libcomps/src/comps_parse.c:445 in comps_parse_check_attributes
Shadow bytes around the buggy address:
  0x0fe2f57a3bc0: 00 00 00 00 00 00 00 00 00 00 00 00 f9 f9 f9 f9
  0x0fe2f57a3bd0: 00 00 00 f9 f9 f9 f9 f9 00 00 00 f9 f9 f9 f9 f9
  0x0fe2f57a3be0: 00 00 00 f9 f9 f9 f9 f9 00 00 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3bf0: 00 00 00 f9 f9 f9 f9 f9 00 00 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3c00: 00 00 00 00 00 f9 f9 f9 f9 f9 f9 f9 00 f9 f9 f9
=>0x0fe2f57a3c10: f9 f9 f9 f9 00[f9]f9 f9 f9 f9 f9 f9 00 00 f9 f9
  0x0fe2f57a3c20: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3c30: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3c40: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3c50: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3c60: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==44258==ABORTING
## Running test_parse2
=================================================================
==44259==ERROR: AddressSanitizer: global-buffer-overflow on address 0x7f13abd5e0a8 at pc 0x7f13abd45b4f bp 0x7ffc12f2d650 sp 0x7ffc12f2d640
READ of size 8 at 0x7f13abd5e0a8 thread T0
    #0 0x7f13abd45b4e in comps_parse_check_attributes /workspace/libcomps/libcomps/src/comps_parse.c:445
    #1 0x7f13abd46164 in comps_parse_start_elem_handler /workspace/libcomps/libcomps/src/comps_parse.c:391
    #2 0x7f13abcd64e3  (/lib/x86_64-linux-gnu/libexpat.so.1+0xa4e3)
    #3 0x7f13abcd76fc  (/lib/x86_64-linux-gnu/libexpat.so.1+0xb6fc)
    #4 0x7f13abcd9e32  (/lib/x86_64-linux-gnu/libexpat.so.1+0xde32)
    #5 0x7f13abcdaf0b  (/lib/x86_64-linux-gnu/libexpat.so.1+0xef0b)
    #6 0x7f13abcd04fe  (/lib/x86_64-linux-gnu/libexpat.so.1+0x44fe)
    #7 0x7f13abcdd486 in XML_ParseBuffer (/lib/x86_64-linux-gnu/libexpat.so.1+0x11486)
    #8 0x7f13abd44fc2 in comps_parse_file /workspace/libcomps/libcomps/src/comps_parse.c:229
    #9 0x55635b1e294f in test_comps_parse2_fn /workspace/libcomps/libcomps/tests/check_parse.c:285
    #10 0x7f13abcc5896 in tcase_run_tfun_fork /workspace/libcomps/check/src/check_run.c:497
    #11 0x7f13abcc5896 in srunner_iterate_tcase_tfuns /workspace/libcomps/check/src/check_run.c:256
    #12 0x7f13abcc5896 in srunner_run_tcase /workspace/libcomps/check/src/check_run.c:402
    #13 0x7f13abcc5896 in srunner_iterate_suites /workspace/libcomps/check/src/check_run.c:222
    #14 0x7f13abcc5896 in srunner_run_tagged /workspace/libcomps/check/src/check_run.c:814
    #15 0x55635b1dc966 in main /workspace/libcomps/libcomps/tests/check_parse.c:668
    #16 0x7f13ab7d8d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)
    #17 0x7f13ab7d8e3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f)
    #18 0x55635b1dca14 in _start (/workspace/libcomps/build/tests/test_parse+0x5a14)

0x7f13abd5e0a8 is located 56 bytes to the left of global variable '__compound_literal.5' defined in '/workspace/libcomps/libcomps/src/comps_elem.c:39:48' (0x7f13abd5e0e0) of size 16
0x7f13abd5e0a8 is located 0 bytes to the right of global variable '__compound_literal.9' defined in '/workspace/libcomps/libcomps/src/comps_elem.c:60:48' (0x7f13abd5e0a0) of size 8
SUMMARY: AddressSanitizer: global-buffer-overflow /workspace/libcomps/libcomps/src/comps_parse.c:445 in comps_parse_check_attributes
Shadow bytes around the buggy address:
  0x0fe2f57a3bc0: 00 00 00 00 00 00 00 00 00 00 00 00 f9 f9 f9 f9
  0x0fe2f57a3bd0: 00 00 00 f9 f9 f9 f9 f9 00 00 00 f9 f9 f9 f9 f9
  0x0fe2f57a3be0: 00 00 00 f9 f9 f9 f9 f9 00 00 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3bf0: 00 00 00 f9 f9 f9 f9 f9 00 00 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3c00: 00 00 00 00 00 f9 f9 f9 f9 f9 f9 f9 00 f9 f9 f9
=>0x0fe2f57a3c10: f9 f9 f9 f9 00[f9]f9 f9 f9 f9 f9 f9 00 00 f9 f9
  0x0fe2f57a3c20: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3c30: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3c40: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3c50: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3c60: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==44259==ABORTING
## Running test_parse3
=================================================================
==44260==ERROR: AddressSanitizer: global-buffer-overflow on address 0x7f13abd5e0a8 at pc 0x7f13abd45b4f bp 0x7ffc12f2d6a0 sp 0x7ffc12f2d690
READ of size 8 at 0x7f13abd5e0a8 thread T0
    #0 0x7f13abd45b4e in comps_parse_check_attributes /workspace/libcomps/libcomps/src/comps_parse.c:445
    #1 0x7f13abd46164 in comps_parse_start_elem_handler /workspace/libcomps/libcomps/src/comps_parse.c:391
    #2 0x7f13abcd64e3  (/lib/x86_64-linux-gnu/libexpat.so.1+0xa4e3)
    #3 0x7f13abcd76fc  (/lib/x86_64-linux-gnu/libexpat.so.1+0xb6fc)
    #4 0x7f13abcd9e32  (/lib/x86_64-linux-gnu/libexpat.so.1+0xde32)
    #5 0x7f13abcdaf0b  (/lib/x86_64-linux-gnu/libexpat.so.1+0xef0b)
    #6 0x7f13abcd04fe  (/lib/x86_64-linux-gnu/libexpat.so.1+0x44fe)
    #7 0x7f13abcdd486 in XML_ParseBuffer (/lib/x86_64-linux-gnu/libexpat.so.1+0x11486)
    #8 0x7f13abd44fc2 in comps_parse_file /workspace/libcomps/libcomps/src/comps_parse.c:229
    #9 0x55635b1e20ed in test_comps_parse3_fn /workspace/libcomps/libcomps/tests/check_parse.c:325
    #10 0x7f13abcc5896 in tcase_run_tfun_fork /workspace/libcomps/check/src/check_run.c:497
    #11 0x7f13abcc5896 in srunner_iterate_tcase_tfuns /workspace/libcomps/check/src/check_run.c:256
    #12 0x7f13abcc5896 in srunner_run_tcase /workspace/libcomps/check/src/check_run.c:402
    #13 0x7f13abcc5896 in srunner_iterate_suites /workspace/libcomps/check/src/check_run.c:222
    #14 0x7f13abcc5896 in srunner_run_tagged /workspace/libcomps/check/src/check_run.c:814
    #15 0x55635b1dc966 in main /workspace/libcomps/libcomps/tests/check_parse.c:668
    #16 0x7f13ab7d8d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)
    #17 0x7f13ab7d8e3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f)
    #18 0x55635b1dca14 in _start (/workspace/libcomps/build/tests/test_parse+0x5a14)

0x7f13abd5e0a8 is located 56 bytes to the left of global variable '__compound_literal.5' defined in '/workspace/libcomps/libcomps/src/comps_elem.c:39:48' (0x7f13abd5e0e0) of size 16
0x7f13abd5e0a8 is located 0 bytes to the right of global variable '__compound_literal.9' defined in '/workspace/libcomps/libcomps/src/comps_elem.c:60:48' (0x7f13abd5e0a0) of size 8
SUMMARY: AddressSanitizer: global-buffer-overflow /workspace/libcomps/libcomps/src/comps_parse.c:445 in comps_parse_check_attributes
Shadow bytes around the buggy address:
  0x0fe2f57a3bc0: 00 00 00 00 00 00 00 00 00 00 00 00 f9 f9 f9 f9
  0x0fe2f57a3bd0: 00 00 00 f9 f9 f9 f9 f9 00 00 00 f9 f9 f9 f9 f9
  0x0fe2f57a3be0: 00 00 00 f9 f9 f9 f9 f9 00 00 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3bf0: 00 00 00 f9 f9 f9 f9 f9 00 00 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3c00: 00 00 00 00 00 f9 f9 f9 f9 f9 f9 f9 00 f9 f9 f9
=>0x0fe2f57a3c10: f9 f9 f9 f9 00[f9]f9 f9 f9 f9 f9 f9 00 00 f9 f9
  0x0fe2f57a3c20: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3c30: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3c40: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3c50: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3c60: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==44260==ABORTING
## Running test_parse4
=================================================================
==44261==ERROR: AddressSanitizer: global-buffer-overflow on address 0x7f13abd5e0a8 at pc 0x7f13abd45b4f bp 0x7ffc12f2d640 sp 0x7ffc12f2d630
READ of size 8 at 0x7f13abd5e0a8 thread T0
    #0 0x7f13abd45b4e in comps_parse_check_attributes /workspace/libcomps/libcomps/src/comps_parse.c:445
    #1 0x7f13abd46164 in comps_parse_start_elem_handler /workspace/libcomps/libcomps/src/comps_parse.c:391
    #2 0x7f13abcd64e3  (/lib/x86_64-linux-gnu/libexpat.so.1+0xa4e3)
    #3 0x7f13abcd76fc  (/lib/x86_64-linux-gnu/libexpat.so.1+0xb6fc)
    #4 0x7f13abcd9e32  (/lib/x86_64-linux-gnu/libexpat.so.1+0xde32)
    #5 0x7f13abcdaf0b  (/lib/x86_64-linux-gnu/libexpat.so.1+0xef0b)
    #6 0x7f13abcd04fe  (/lib/x86_64-linux-gnu/libexpat.so.1+0x44fe)
    #7 0x7f13abcdd486 in XML_ParseBuffer (/lib/x86_64-linux-gnu/libexpat.so.1+0x11486)
    #8 0x7f13abd44fc2 in comps_parse_file /workspace/libcomps/libcomps/src/comps_parse.c:229
    #9 0x55635b1e1cad in test_comps_parse4_fn /workspace/libcomps/libcomps/tests/check_parse.c:418
    #10 0x7f13abcc5896 in tcase_run_tfun_fork /workspace/libcomps/check/src/check_run.c:497
    #11 0x7f13abcc5896 in srunner_iterate_tcase_tfuns /workspace/libcomps/check/src/check_run.c:256
    #12 0x7f13abcc5896 in srunner_run_tcase /workspace/libcomps/check/src/check_run.c:402
    #13 0x7f13abcc5896 in srunner_iterate_suites /workspace/libcomps/check/src/check_run.c:222
    #14 0x7f13abcc5896 in srunner_run_tagged /workspace/libcomps/check/src/check_run.c:814
    #15 0x55635b1dc966 in main /workspace/libcomps/libcomps/tests/check_parse.c:668
    #16 0x7f13ab7d8d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)
    #17 0x7f13ab7d8e3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f)
    #18 0x55635b1dca14 in _start (/workspace/libcomps/build/tests/test_parse+0x5a14)

0x7f13abd5e0a8 is located 56 bytes to the left of global variable '__compound_literal.5' defined in '/workspace/libcomps/libcomps/src/comps_elem.c:39:48' (0x7f13abd5e0e0) of size 16
0x7f13abd5e0a8 is located 0 bytes to the right of global variable '__compound_literal.9' defined in '/workspace/libcomps/libcomps/src/comps_elem.c:60:48' (0x7f13abd5e0a0) of size 8
SUMMARY: AddressSanitizer: global-buffer-overflow /workspace/libcomps/libcomps/src/comps_parse.c:445 in comps_parse_check_attributes
Shadow bytes around the buggy address:
  0x0fe2f57a3bc0: 00 00 00 00 00 00 00 00 00 00 00 00 f9 f9 f9 f9
  0x0fe2f57a3bd0: 00 00 00 f9 f9 f9 f9 f9 00 00 00 f9 f9 f9 f9 f9
  0x0fe2f57a3be0: 00 00 00 f9 f9 f9 f9 f9 00 00 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3bf0: 00 00 00 f9 f9 f9 f9 f9 00 00 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3c00: 00 00 00 00 00 f9 f9 f9 f9 f9 f9 f9 00 f9 f9 f9
=>0x0fe2f57a3c10: f9 f9 f9 f9 00[f9]f9 f9 f9 f9 f9 f9 00 00 f9 f9
  0x0fe2f57a3c20: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3c30: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3c40: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3c50: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3c60: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==44261==ABORTING
## Running test_parse5
=================================================================
==44262==ERROR: AddressSanitizer: global-buffer-overflow on address 0x7f13abd5e0a8 at pc 0x7f13abd45b4f bp 0x7ffc12f2d6b0 sp 0x7ffc12f2d6a0
READ of size 8 at 0x7f13abd5e0a8 thread T0
    #0 0x7f13abd45b4e in comps_parse_check_attributes /workspace/libcomps/libcomps/src/comps_parse.c:445
    #1 0x7f13abd46164 in comps_parse_start_elem_handler /workspace/libcomps/libcomps/src/comps_parse.c:391
    #2 0x7f13abcd64e3  (/lib/x86_64-linux-gnu/libexpat.so.1+0xa4e3)
    #3 0x7f13abcd76fc  (/lib/x86_64-linux-gnu/libexpat.so.1+0xb6fc)
    #4 0x7f13abcd9e32  (/lib/x86_64-linux-gnu/libexpat.so.1+0xde32)
    #5 0x7f13abcdaf0b  (/lib/x86_64-linux-gnu/libexpat.so.1+0xef0b)
    #6 0x7f13abcd04fe  (/lib/x86_64-linux-gnu/libexpat.so.1+0x44fe)
    #7 0x7f13abcdd486 in XML_ParseBuffer (/lib/x86_64-linux-gnu/libexpat.so.1+0x11486)
    #8 0x7f13abd44fc2 in comps_parse_file /workspace/libcomps/libcomps/src/comps_parse.c:229
    #9 0x55635b1e1425 in test_comps_parse5_fn /workspace/libcomps/libcomps/tests/check_parse.c:451
    #10 0x7f13abcc5896 in tcase_run_tfun_fork /workspace/libcomps/check/src/check_run.c:497
    #11 0x7f13abcc5896 in srunner_iterate_tcase_tfuns /workspace/libcomps/check/src/check_run.c:256
    #12 0x7f13abcc5896 in srunner_run_tcase /workspace/libcomps/check/src/check_run.c:402
    #13 0x7f13abcc5896 in srunner_iterate_suites /workspace/libcomps/check/src/check_run.c:222
    #14 0x7f13abcc5896 in srunner_run_tagged /workspace/libcomps/check/src/check_run.c:814
    #15 0x55635b1dc966 in main /workspace/libcomps/libcomps/tests/check_parse.c:668
    #16 0x7f13ab7d8d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)
    #17 0x7f13ab7d8e3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f)
    #18 0x55635b1dca14 in _start (/workspace/libcomps/build/tests/test_parse+0x5a14)

0x7f13abd5e0a8 is located 56 bytes to the left of global variable '__compound_literal.5' defined in '/workspace/libcomps/libcomps/src/comps_elem.c:39:48' (0x7f13abd5e0e0) of size 16
0x7f13abd5e0a8 is located 0 bytes to the right of global variable '__compound_literal.9' defined in '/workspace/libcomps/libcomps/src/comps_elem.c:60:48' (0x7f13abd5e0a0) of size 8
SUMMARY: AddressSanitizer: global-buffer-overflow /workspace/libcomps/libcomps/src/comps_parse.c:445 in comps_parse_check_attributes
Shadow bytes around the buggy address:
  0x0fe2f57a3bc0: 00 00 00 00 00 00 00 00 00 00 00 00 f9 f9 f9 f9
  0x0fe2f57a3bd0: 00 00 00 f9 f9 f9 f9 f9 00 00 00 f9 f9 f9 f9 f9
  0x0fe2f57a3be0: 00 00 00 f9 f9 f9 f9 f9 00 00 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3bf0: 00 00 00 f9 f9 f9 f9 f9 00 00 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3c00: 00 00 00 00 00 f9 f9 f9 f9 f9 f9 f9 00 f9 f9 f9
=>0x0fe2f57a3c10: f9 f9 f9 f9 00[f9]f9 f9 f9 f9 f9 f9 00 00 f9 f9
  0x0fe2f57a3c20: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3c30: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3c40: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3c50: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3c60: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==44262==ABORTING
## Running test_parse fedora
=================================================================
==44263==ERROR: AddressSanitizer: global-buffer-overflow on address 0x7f13abd5e0a8 at pc 0x7f13abd45b4f bp 0x7ffc12f2d750 sp 0x7ffc12f2d740
READ of size 8 at 0x7f13abd5e0a8 thread T0
    #0 0x7f13abd45b4e in comps_parse_check_attributes /workspace/libcomps/libcomps/src/comps_parse.c:445
    #1 0x7f13abd46164 in comps_parse_start_elem_handler /workspace/libcomps/libcomps/src/comps_parse.c:391
    #2 0x7f13abcd64e3  (/lib/x86_64-linux-gnu/libexpat.so.1+0xa4e3)
    #3 0x7f13abcd76fc  (/lib/x86_64-linux-gnu/libexpat.so.1+0xb6fc)
    #4 0x7f13abcd9e32  (/lib/x86_64-linux-gnu/libexpat.so.1+0xde32)
    #5 0x7f13abcdaf0b  (/lib/x86_64-linux-gnu/libexpat.so.1+0xef0b)
    #6 0x7f13abcd04fe  (/lib/x86_64-linux-gnu/libexpat.so.1+0x44fe)
    #7 0x7f13abcdd486 in XML_ParseBuffer (/lib/x86_64-linux-gnu/libexpat.so.1+0x11486)
    #8 0x7f13abd44fc2 in comps_parse_file /workspace/libcomps/libcomps/src/comps_parse.c:229
    #9 0x55635b1df4e6 in test_comps_fedora_parse_fn /workspace/libcomps/libcomps/tests/check_parse.c:477
    #10 0x7f13abcc5896 in tcase_run_tfun_fork /workspace/libcomps/check/src/check_run.c:497
    #11 0x7f13abcc5896 in srunner_iterate_tcase_tfuns /workspace/libcomps/check/src/check_run.c:256
    #12 0x7f13abcc5896 in srunner_run_tcase /workspace/libcomps/check/src/check_run.c:402
    #13 0x7f13abcc5896 in srunner_iterate_suites /workspace/libcomps/check/src/check_run.c:222
    #14 0x7f13abcc5896 in srunner_run_tagged /workspace/libcomps/check/src/check_run.c:814
    #15 0x55635b1dc966 in main /workspace/libcomps/libcomps/tests/check_parse.c:668
    #16 0x7f13ab7d8d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)
    #17 0x7f13ab7d8e3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f)
    #18 0x55635b1dca14 in _start (/workspace/libcomps/build/tests/test_parse+0x5a14)

0x7f13abd5e0a8 is located 56 bytes to the left of global variable '__compound_literal.5' defined in '/workspace/libcomps/libcomps/src/comps_elem.c:39:48' (0x7f13abd5e0e0) of size 16
0x7f13abd5e0a8 is located 0 bytes to the right of global variable '__compound_literal.9' defined in '/workspace/libcomps/libcomps/src/comps_elem.c:60:48' (0x7f13abd5e0a0) of size 8
SUMMARY: AddressSanitizer: global-buffer-overflow /workspace/libcomps/libcomps/src/comps_parse.c:445 in comps_parse_check_attributes
Shadow bytes around the buggy address:
  0x0fe2f57a3bc0: 00 00 00 00 00 00 00 00 00 00 00 00 f9 f9 f9 f9
  0x0fe2f57a3bd0: 00 00 00 f9 f9 f9 f9 f9 00 00 00 f9 f9 f9 f9 f9
  0x0fe2f57a3be0: 00 00 00 f9 f9 f9 f9 f9 00 00 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3bf0: 00 00 00 f9 f9 f9 f9 f9 00 00 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3c00: 00 00 00 00 00 f9 f9 f9 f9 f9 f9 f9 00 f9 f9 f9
=>0x0fe2f57a3c10: f9 f9 f9 f9 00[f9]f9 f9 f9 f9 f9 f9 00 00 f9 f9
  0x0fe2f57a3c20: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3c30: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3c40: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3c50: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3c60: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==44263==ABORTING
## Running test_parse main2
=================================================================
==44264==ERROR: AddressSanitizer: global-buffer-overflow on address 0x7f13abd5e0a8 at pc 0x7f13abd45b4f bp 0x7ffc12f2d750 sp 0x7ffc12f2d740
READ of size 8 at 0x7f13abd5e0a8 thread T0
    #0 0x7f13abd45b4e in comps_parse_check_attributes /workspace/libcomps/libcomps/src/comps_parse.c:445
    #1 0x7f13abd46164 in comps_parse_start_elem_handler /workspace/libcomps/libcomps/src/comps_parse.c:391
    #2 0x7f13abcd64e3  (/lib/x86_64-linux-gnu/libexpat.so.1+0xa4e3)
    #3 0x7f13abcd76fc  (/lib/x86_64-linux-gnu/libexpat.so.1+0xb6fc)
    #4 0x7f13abcd9e32  (/lib/x86_64-linux-gnu/libexpat.so.1+0xde32)
    #5 0x7f13abcdaf0b  (/lib/x86_64-linux-gnu/libexpat.so.1+0xef0b)
    #6 0x7f13abcd04fe  (/lib/x86_64-linux-gnu/libexpat.so.1+0x44fe)
    #7 0x7f13abcdd486 in XML_ParseBuffer (/lib/x86_64-linux-gnu/libexpat.so.1+0x11486)
    #8 0x7f13abd44fc2 in comps_parse_file /workspace/libcomps/libcomps/src/comps_parse.c:229
    #9 0x55635b1df3c2 in test_main2_fn /workspace/libcomps/libcomps/tests/check_parse.c:506
    #10 0x7f13abcc5896 in tcase_run_tfun_fork /workspace/libcomps/check/src/check_run.c:497
    #11 0x7f13abcc5896 in srunner_iterate_tcase_tfuns /workspace/libcomps/check/src/check_run.c:256
    #12 0x7f13abcc5896 in srunner_run_tcase /workspace/libcomps/check/src/check_run.c:402
    #13 0x7f13abcc5896 in srunner_iterate_suites /workspace/libcomps/check/src/check_run.c:222
    #14 0x7f13abcc5896 in srunner_run_tagged /workspace/libcomps/check/src/check_run.c:814
    #15 0x55635b1dc966 in main /workspace/libcomps/libcomps/tests/check_parse.c:668
    #16 0x7f13ab7d8d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)
    #17 0x7f13ab7d8e3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f)
    #18 0x55635b1dca14 in _start (/workspace/libcomps/build/tests/test_parse+0x5a14)

0x7f13abd5e0a8 is located 56 bytes to the left of global variable '__compound_literal.5' defined in '/workspace/libcomps/libcomps/src/comps_elem.c:39:48' (0x7f13abd5e0e0) of size 16
0x7f13abd5e0a8 is located 0 bytes to the right of global variable '__compound_literal.9' defined in '/workspace/libcomps/libcomps/src/comps_elem.c:60:48' (0x7f13abd5e0a0) of size 8
SUMMARY: AddressSanitizer: global-buffer-overflow /workspace/libcomps/libcomps/src/comps_parse.c:445 in comps_parse_check_attributes
Shadow bytes around the buggy address:
  0x0fe2f57a3bc0: 00 00 00 00 00 00 00 00 00 00 00 00 f9 f9 f9 f9
  0x0fe2f57a3bd0: 00 00 00 f9 f9 f9 f9 f9 00 00 00 f9 f9 f9 f9 f9
  0x0fe2f57a3be0: 00 00 00 f9 f9 f9 f9 f9 00 00 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3bf0: 00 00 00 f9 f9 f9 f9 f9 00 00 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3c00: 00 00 00 00 00 f9 f9 f9 f9 f9 f9 f9 00 f9 f9 f9
=>0x0fe2f57a3c10: f9 f9 f9 f9 00[f9]f9 f9 f9 f9 f9 f9 00 00 f9 f9
  0x0fe2f57a3c20: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3c30: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3c40: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3c50: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3c60: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==44264==ABORTING
## Running test_parse arch
=================================================================
==44265==ERROR: AddressSanitizer: global-buffer-overflow on address 0x7f13abd5e0a8 at pc 0x7f13abd45b4f bp 0x7ffc12f2d080 sp 0x7ffc12f2d070
READ of size 8 at 0x7f13abd5e0a8 thread T0
    #0 0x7f13abd45b4e in comps_parse_check_attributes /workspace/libcomps/libcomps/src/comps_parse.c:445
    #1 0x7f13abd46164 in comps_parse_start_elem_handler /workspace/libcomps/libcomps/src/comps_parse.c:391
    #2 0x7f13abcd64e3  (/lib/x86_64-linux-gnu/libexpat.so.1+0xa4e3)
    #3 0x7f13abcd76fc  (/lib/x86_64-linux-gnu/libexpat.so.1+0xb6fc)
    #4 0x7f13abcd9e32  (/lib/x86_64-linux-gnu/libexpat.so.1+0xde32)
    #5 0x7f13abcdaf0b  (/lib/x86_64-linux-gnu/libexpat.so.1+0xef0b)
    #6 0x7f13abcd04fe  (/lib/x86_64-linux-gnu/libexpat.so.1+0x44fe)
    #7 0x7f13abcdd486 in XML_ParseBuffer (/lib/x86_64-linux-gnu/libexpat.so.1+0x11486)
    #8 0x7f13abd44fc2 in comps_parse_file /workspace/libcomps/libcomps/src/comps_parse.c:229
    #9 0x55635b1de300 in test_arch_fn /workspace/libcomps/libcomps/tests/check_parse.c:555
    #10 0x7f13abcc5896 in tcase_run_tfun_fork /workspace/libcomps/check/src/check_run.c:497
    #11 0x7f13abcc5896 in srunner_iterate_tcase_tfuns /workspace/libcomps/check/src/check_run.c:256
    #12 0x7f13abcc5896 in srunner_run_tcase /workspace/libcomps/check/src/check_run.c:402
    #13 0x7f13abcc5896 in srunner_iterate_suites /workspace/libcomps/check/src/check_run.c:222
    #14 0x7f13abcc5896 in srunner_run_tagged /workspace/libcomps/check/src/check_run.c:814
    #15 0x55635b1dc966 in main /workspace/libcomps/libcomps/tests/check_parse.c:668
    #16 0x7f13ab7d8d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f)
    #17 0x7f13ab7d8e3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f)
    #18 0x55635b1dca14 in _start (/workspace/libcomps/build/tests/test_parse+0x5a14)

0x7f13abd5e0a8 is located 56 bytes to the left of global variable '__compound_literal.5' defined in '/workspace/libcomps/libcomps/src/comps_elem.c:39:48' (0x7f13abd5e0e0) of size 16
0x7f13abd5e0a8 is located 0 bytes to the right of global variable '__compound_literal.9' defined in '/workspace/libcomps/libcomps/src/comps_elem.c:60:48' (0x7f13abd5e0a0) of size 8
SUMMARY: AddressSanitizer: global-buffer-overflow /workspace/libcomps/libcomps/src/comps_parse.c:445 in comps_parse_check_attributes
Shadow bytes around the buggy address:
  0x0fe2f57a3bc0: 00 00 00 00 00 00 00 00 00 00 00 00 f9 f9 f9 f9
  0x0fe2f57a3bd0: 00 00 00 f9 f9 f9 f9 f9 00 00 00 f9 f9 f9 f9 f9
  0x0fe2f57a3be0: 00 00 00 f9 f9 f9 f9 f9 00 00 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3bf0: 00 00 00 f9 f9 f9 f9 f9 00 00 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3c00: 00 00 00 00 00 f9 f9 f9 f9 f9 f9 f9 00 f9 f9 f9
=>0x0fe2f57a3c10: f9 f9 f9 f9 00[f9]f9 f9 f9 f9 f9 f9 00 00 f9 f9
  0x0fe2f57a3c20: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3c30: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3c40: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3c50: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
  0x0fe2f57a3c60: f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9 f9
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==44265==ABORTING
make[3]: *** [tests/CMakeFiles/test_parse_run.dir/build.make:71: tests/CMakeFiles/test_parse_run] Error 1
make[2]: *** [CMakeFiles/Makefile2:791: tests/CMakeFiles/test_parse_run.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:311: CMakeFiles/test.dir/rule] Error 2
make: *** [Makefile:195: test] Error 2
```
</details>

It turned out that it was caused by the fact that some of the `atributes` of the objects of `COMPS_ElemInfo` were not `NULL`-terminated.