### PR TITLE
fix: call `COMPS_OBJECT_DESTROY` prior to return statement to prevent leak

### DIFF
--- a/libcomps/src/python/src/pycomps.c
+++ b/libcomps/src/python/src/pycomps.c
@@ -642,8 +642,8 @@ PyObject* PyCOMPS_validate_nf(PyCOMPS *comps) {
             PyList_Append(list, PyUnicode_FromString(
                                     ((COMPS_ValErr*)it->comps_obj)->err_msg));
         }
-        return list;
         COMPS_OBJECT_DESTROY(result);
+        return list;
     }
     #undef _result_
 }


### PR DESCRIPTION
Note that in the original code `COMPS_OBJECT_DESTROY` is never executed.