### PR TITLE
fix: use `%u` when dealing with unsigned variabnles in `printf`

### DIFF
--- a/libcomps/src/comps_mradix.c
+++ b/libcomps/src/comps_mradix.c
@@ -87,7 +87,7 @@ void comps_mrtree_destroy(COMPS_MRTree * rt) {
 void comps_mrtree_print(COMPS_HSList * hl, unsigned  deep) {
     COMPS_HSListItem * it;
     for (it = hl->first; it != NULL; it=it->next) {
-        printf("%d %s\n",deep, (((COMPS_MRTreeData*)it->data)->key));
+        printf("%u %s\n",deep, (((COMPS_MRTreeData*)it->data)->key));
         comps_mrtree_print(((COMPS_MRTreeData*)it->data)->subnodes, deep+1);
     }
 }

--- a/libcomps/src/comps_radix.c
+++ b/libcomps/src/comps_radix.c
@@ -97,7 +97,7 @@ void comps_rtree_destroy(COMPS_RTree * rt) {
 void comps_rtree_print(COMPS_HSList * hl, unsigned  deep) {
     COMPS_HSListItem * it;
     for (it = hl->first; it != NULL; it=it->next) {
-        printf("%d %s\n",deep, (((COMPS_RTreeData*)it->data)->key));
+        printf("%u %s\n",deep, (((COMPS_RTreeData*)it->data)->key));
         comps_rtree_print(((COMPS_RTreeData*)it->data)->subnodes, deep+1);
     }
 }


### PR DESCRIPTION
Using a wrong format specifier in `printf` can lead to undefined behavior. 