### PR TITLE
Configure packit to use caret notation for postrelease snapshots

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,5 +1,8 @@
 # See the documentation for more information:
 # https://packit.dev/docs/configuration
 
+version_suffix: "^{PACKIT_PROJECT_SNAPSHOTID}"
+update_release: false
+
 # To disable default jobs set them as empty
 jobs: []

--- a/libcomps.spec
+++ b/libcomps.spec
@@ -113,6 +113,6 @@ popd
 
 %files -n python3-%{name}
 %{python3_sitearch}/%{name}/
-%{python3_sitearch}/%{name}-%{version}-py%{python3_version}.egg-info
+%{python3_sitearch}/%{name}-*-py%{python3_version}.egg-info
 
 %changelog


### PR DESCRIPTION
This ensures the build of that specific version is considered newer than any other regular release of it.
For rpm-software-management/ci-dnf-stack#1843

It also updates the spec to accept python metadata of any version. This is needed for the snapshot builds because they have different cmake/python metadata and spec versions.

Example build: https://copr.fedorainfracloud.org/coprs/amatej/dnf-nightly/build/10266094/